### PR TITLE
Revert "CLUS-1752: 'vendor' input is required for 'postgresql' cluster"

### DIFF
--- a/libs9s/s9srpcclient.cpp
+++ b/libs9s/s9srpcclient.cpp
@@ -3134,7 +3134,8 @@ S9sRpcClient::createCluster()
     osUserName     = options->osUser();
     vendor         = options->vendor();
 
-    if (vendor.empty())
+
+    if (vendor.empty() && options->clusterType() != "postgresql")
     {
         PRINT_ERROR(
             "The vendor name is unknown while creating a cluster.\n"


### PR DESCRIPTION
This reverts commit da9a52473bee341800f1869a8923c9fe61dd4bec.