### PR TITLE
CLUS-2112 Make sure ssh_keyfile in RPC requests has a default as ~/.s…

### DIFF
--- a/libs9s/s9soptions.cpp
+++ b/libs9s/s9soptions.cpp
@@ -567,7 +567,7 @@ S9sOptions::createConfigFiles()
     userFile.fprintf("#\n");
     userFile.fprintf("# os_user          = some_user\n");
     userFile.fprintf("# os_sudo_password = some_password\n");
-    userFile.fprintf("# os_key_file      = /home/some_user/.ssh/test_ssh_key\n");
+    userFile.fprintf("# os_key_file      = /home/some_user/.ssh/id_rsa\n");
     userFile.fprintf("\n");
 }
 
@@ -1971,8 +1971,7 @@ S9sOptions::sshCredentials(
  * key.
  */
 S9sString
-S9sOptions::osUser(
-        bool defaultsToCmonUser) const
+S9sOptions::osUser() const
 {
     S9sString retval;
 
@@ -1986,8 +1985,8 @@ S9sOptions::osUser(
             retval = m_systemConfig.variableValue("os_user");
     }
 
-    if (retval.empty() && defaultsToCmonUser)
-        retval = userName();
+    if (retval.empty())
+        retval = getenv("USER");
 
     return retval;
 }
@@ -2030,6 +2029,12 @@ S9sOptions::osKeyFile() const
 
         if (retval.empty())
             retval = m_systemConfig.variableValue("os_key_file");
+
+        if (retval.empty())
+        {
+            retval = getenv("HOME");
+            retval += "/.ssh/id_rsa";
+        }
     }
 
     return retval;

--- a/libs9s/s9soptions.h
+++ b/libs9s/s9soptions.h
@@ -189,7 +189,7 @@ class S9sOptions
                     const S9sString &categoryName = "",
                     const S9sString &hostName = "");
 
-        S9sString osUser(bool defaultsToCmonUser = true) const;
+        S9sString osUser() const;
         S9sString osKeyFile() const;
         S9sString osPassword() const;
 

--- a/libs9s/s9srpcclient.cpp
+++ b/libs9s/s9srpcclient.cpp
@@ -10762,7 +10762,7 @@ S9sRpcClient::addCredentialsToJobData(
 {
     S9sOptions    *options      = S9sOptions::instance();
 
-    S9sString      osUserName     = options->osUser(false);
+    S9sString      osUserName     = options->osUser();
     S9sString      osKeyFile      = options->osKeyFile();
     S9sString      osPassword     = options->osPassword();
     S9sString      osSudoPassword = options->osSudoPassword();


### PR DESCRIPTION
…sh/id_rsa if not specified in ~/.s9s/s9s.conf and neither on the command line

Partial fix. Hopefully enough for the s9s tools side.