### PR TITLE
GCC: fix -Werror=overloaded-virtual error

### DIFF
--- a/tests/ut_s9srpcclient/ut_s9srpcclient.cpp
+++ b/tests/ut_s9srpcclient/ut_s9srpcclient.cpp
@@ -34,7 +34,8 @@
 bool 
 S9sRpcClientTester::doExecuteRequest(
         const S9sString &uri,
-        S9sVariantMap &payload)
+        S9sVariantMap &payload,
+        S9s::Redirect redirect)
 {
     S9S_DEBUG("*** ");
     S9S_DEBUG("*** uri     : %s", STR(uri));

--- a/tests/ut_s9srpcclient/ut_s9srpcclient.h
+++ b/tests/ut_s9srpcclient/ut_s9srpcclient.h
@@ -107,7 +107,8 @@ class S9sRpcClientTester : public S9sRpcClient
        virtual bool 
             doExecuteRequest(
                 const S9sString &uri,
-                S9sVariantMap &payload);
+                S9sVariantMap &payload,
+                S9s::Redirect redirect);
 
     private:
         S9sVariantList    m_urls;


### PR DESCRIPTION
Fixes:

```
  CXX      ut_s9srpcclient.o
In file included from ../../libs9s/S9sRpcClient:1,
                 from ut_s9srpcclient.h:22,
                 from ut_s9srpcclient.cpp:20:
../../libs9s/s9srpcclient.h:468:22: error: ‘virtual bool S9sRpcClient::doExecuteRequest(const S9sString&, S9sVariantMap&, S9s::Redirect)’ was hidden [-Werror=overloaded-virtual=]
  468 |         virtual bool doExecuteRequest(
      |                      ^~~~~~~~~~~~~~~~
ut_s9srpcclient.h:108:13: note:   by ‘virtual bool S9sRpcClientTester::doExecuteRequest(const S9sString&, S9sVariantMap&)’
  108 |             doExecuteRequest(
      |             ^~~~~~~~~~~~~~~~
```