### PR TITLE
Clus 2228

### DIFF
--- a/libs9s/s9srpcclient.cpp
+++ b/libs9s/s9srpcclient.cpp
@@ -2525,12 +2525,21 @@ S9sRpcClient::inspectHost()
 bool
 S9sRpcClient::rollingRestart()
 {
+    S9sOptions    *options = S9sOptions::instance();
     S9sVariantMap  request = composeRequest();
     S9sVariantMap  job     = composeJob();
+    S9sVariantMap  jobData = composeJobData();
     S9sVariantMap  jobSpec;
     S9sString      uri = "/v2/jobs/";
 
+    // The job_data.
+    if (options->hasTimeout())
+        jobData["stop_timeout"] = options->timeout();
+    else
+        jobData["stop_timeout"] = 1800;
+
     jobSpec["command"]    = "rolling_restart";
+    jobSpec["job_data"]   = jobData;
 
     // The job instance describing how the job will be executed.
     job["title"]          = "Rolling Restart";
@@ -6319,8 +6328,11 @@ S9sRpcClient::stopCluster()
     title = "Stopping Cluster";
 
     // The job_data.
-    jobData["stop_timeout"]        = 1800;
-    
+    if (options->hasTimeout())
+        jobData["stop_timeout"] = options->timeout();
+    else
+        jobData["stop_timeout"] = 1800;
+
     if (options->hasMinutes())
         jobData["maintenance_minutes"] = options->minutes();
 

--- a/libs9s/s9srpcclient.cpp
+++ b/libs9s/s9srpcclient.cpp
@@ -3722,6 +3722,14 @@ S9sRpcClient::registerHost()
     {
         command = "registernode";
         title   = "Register MongoDb Node";
+    } else if (protocol == "mongocfg")
+    {
+        command = "registernode";
+        title   = "Register MongoCfg Node";
+    } else if (protocol == "mongos")
+    {
+        command = "registernode";
+        title   = "Register Mongos Node";
     } else {
         command = protocol;
         title   = "Register Node";


### PR DESCRIPTION
Passing timeout for stop cluster and rolling restart cluster operations/jobs is more user friendly compared to hard coded cmon values and is helping testing. In test a short timeout is enough for us with our empty databases.

Please not yesterday evening at 18:00 I started a stop start test and it finished around 22:00 because for each node the timeout was 30 minutes.