### PR TITLE
CLUS-4433 a log message id should be of int type

### DIFF
--- a/libs9s/s9sdatetime.cpp
+++ b/libs9s/s9sdatetime.cpp
@@ -588,17 +588,6 @@ S9sDateTime::toString(
                 retval += "Z";
             }
             break;
-
-        case LogIdDateFormat:
-            {
-                char buffer[120] = {0}; //NOLINT
-                if (strftime(buffer, sizeof(buffer), "%Y%m%d_%H%M%S_", lt) == 0)
-                    retval = "_strftime_failed_";
-                else
-                    retval = buffer;
-            }
-            break;
-
     }
     return retval;
 }

--- a/libs9s/s9sdatetime.h
+++ b/libs9s/s9sdatetime.h
@@ -72,8 +72,6 @@ class S9sDateTime
             EmailDateTimeFormat,
             /** "2015-11-19T04:46:01.000Z" */
             TzDateTimeFormat,
-            /** "20240510_131501_", with log_id is used for unique Log Message ID: 20240510_131501_1767 */
-            LogIdDateFormat,
         };
 
         S9sDateTime();

--- a/libs9s/s9smessage.cpp
+++ b/libs9s/s9smessage.cpp
@@ -461,15 +461,6 @@ S9sMessage::toString(
                     retval += tmp;
                     break;
                 
-                case 'D':
-                    // The 'created' date&time.
-                    partFormat += 's';
-                    tmp.sprintf(
-                            STR(partFormat),
-                            STR(created().toString(S9sDateTime::LogIdDateFormat)));
-                    retval += tmp;
-                    break;
-
                 case 'h':
                     // The related host name. 
                     partFormat += 's';
@@ -485,7 +476,7 @@ S9sMessage::toString(
                     break;
                 
                 case 'I':
-                    // The message ID.
+                    // The message ID to pass to cmon, e.g. for a logs request
                     partFormat += 'd';
                     tmp.sprintf(STR(partFormat), messageId());
                     retval += tmp;

--- a/libs9s/s9srpcreply.cpp
+++ b/libs9s/s9srpcreply.cpp
@@ -3392,7 +3392,7 @@ S9sRpcReply::printLogLong()
     // code is used here as it is added to the brief format.
     if (!hasLogFormatFile && formatString.empty())
     {
-        formatString = "%D%I %36B:%-5L: %-8S %M\n";
+        formatString = "%C %36B:%-5L: %-8S %M\n";
     }
 
     for (uint idx = 0; idx < theList.size(); ++idx)

--- a/tests/ut_s9sdatetime/ut_s9sdatetime.cpp
+++ b/tests/ut_s9sdatetime/ut_s9sdatetime.cpp
@@ -69,23 +69,11 @@ UtS9sDateTime::testCreate()
             STR(dateTime.toString(S9sDateTime::TzDateTimeFormat)));
     S9S_DEBUG("  LongTimeFormat : %s",
             STR(dateTime.toString(S9sDateTime::LongTimeFormat)));
-    S9S_DEBUG("<> Local TZ time <> LogIdDateFormat <>: <>%s<>",
-            STR(dateTime.toString(S9sDateTime::LogIdDateFormat)));
     S9S_DEBUG("");
 
     S9S_VERIFY(
             dateTime.toString(S9sDateTime::TzDateTimeFormat).
             contains("T07:13:54.000Z"));
-
-    setenv("TZ", "/usr/share/zoneinfo/Europe/UTC", 1); // NOLINT
-    tzset();
-    S9S_DEBUG("");
-    S9S_DEBUG("<> UTC time <> LogIdDateFormat <>: <>%s<>",
-            STR(dateTime.toString(S9sDateTime::LogIdDateFormat)));
-    S9S_DEBUG("");
-    S9S_VERIFY(
-            dateTime.toString(S9sDateTime::LogIdDateFormat).
-            contains("_071354_"));
 
     return true;
 }


### PR DESCRIPTION
for backward compatibility with 's9s log --list --message-id=400' requests