### PR TITLE
CLUS-4412 CLI fixes and improvements around backups

### DIFF
--- a/doc/s9s-backup.1
+++ b/doc/s9s-backup.1
@@ -723,8 +723,8 @@ are going to be archived into the backup file. By default all the databases are
 going to be archived.
 
 .TP
-.BI \-\^\-compression
-Compress the archive file created by the backup.
+.BI \-\^\-no\-compression
+Do not compress the archive file created by the backup.
 
 .TP
 .BI \-\^\-compression\-level

--- a/libs9s/s9srpcclient.cpp
+++ b/libs9s/s9srpcclient.cpp
@@ -10953,7 +10953,14 @@ S9sRpcClient::composeBackupJob()
             PRINT_ERROR("Compression level must be between 1 and 9. Option ignored.");
         }
         else
-            jobData["compression_level"] = value;
+        {
+            if(options->noCompression())
+                PRINT_ERROR(
+                        "Option --compression-level is ignored due to "
+                        "--no-compression option being set.");
+            else
+                jobData["compression_level"] = value;
+        }
     }
 
     if (options->usePigz())


### PR DESCRIPTION
- if --no-compression option is provided, --compression-level is ignored and message is printed.
- fixed manpage for --no-compression option.