### PR TITLE
Add `--credential-id` to the cloud-credentials docs and help message

### DIFF
--- a/doc/s9s-cloud-credentials.1
+++ b/doc/s9s-cloud-credentials.1
@@ -104,7 +104,7 @@ Delete a cloud credential stores on CC
 
 .B EXAMPLE
 .nf
-s9s cloud-credentials --delete --id=1 --cloud-provider=aws
+s9s cloud-credentials --delete --credential-id=1 --cloud-provider=aws
 deleted.
 .fi
 
@@ -113,7 +113,7 @@ deleted.
 .\" Arguments related to delete operations
 .\"
 .tp
-.bi \-\^\-id=cc_credentials_id
+.bi \-\^\-credential\-id=cc_credentials_id
 The credential id used on clustercontrol to identify the cloud credential as shown on the list operation.
 
 .tp

--- a/libs9s/s9soptions.cpp
+++ b/libs9s/s9soptions.cpp
@@ -8390,6 +8390,7 @@ S9sOptions::printHelpCloudCredentials()
 "  --create                   To create cloud credential and store on CC.\n"
 "  --delete                   To delete cloud credential stored on CC.\n"
 "  --provider                 To specify the cloud provider of credential create.\n"
+"  --credential-id            To specify the cloud credential ID to delete.\n"
 "  --s3-region                To specify the region (as in cloud provider) of credential to create.\n"
 "  --s3-access-key-id         To specify the access key id (as in cloud provider) of credential to create.\n"
 "  --s3-secret-key            To specify the secret key (as in cloud provider) of credential to create.\n"


### PR DESCRIPTION
I was trying to remove coud credentials by ID and could not find the argument name in the docs.