### PR TITLE
Support --color option in the cloud-credentials list

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ The repository contains the following tools:
 
 # Important
 
-This git repository contains the sources of a development version of s9s-tools,
-this might doesn't work with the current publicly avaible
+This git repository contains s9s-tools development version sources,
+this might not work with the current publicly available
 clustercontrol-controller version, please check relevant versioned branches
 (1.4.2_release).
 

--- a/libs9s/s9srpcreply.cpp
+++ b/libs9s/s9srpcreply.cpp
@@ -1550,12 +1550,14 @@ S9sRpcReply::printCloudCredentialsLong()
 {
     S9sOptions    *options = S9sOptions::instance();
     S9sVariantMap  reqResults = operator[]("result").toVariantMap();
-    S9sFormat      idFormat("\033[95m", TERM_NORMAL);
-    S9sFormat      nameFormat("\033[93m", TERM_NORMAL);
-    S9sFormat      providerFormat("\033[94m", TERM_NORMAL);
-    S9sFormat      regionFormat("\033[33m", TERM_NORMAL);
-    S9sFormat      commentFormat("\033[1m\033[97m", TERM_NORMAL);
-    S9sFormat      endpointFormat("\033[1m\033[97m", TERM_NORMAL);
+    // Initialize formats with colors based on syntax highlighting setting
+    bool useColors = options->useSyntaxHighlight();
+    S9sFormat      idFormat(useColors ? "\033[95m" : "", useColors ? TERM_NORMAL : "");
+    S9sFormat      nameFormat(useColors ? "\033[93m" : "", useColors ? TERM_NORMAL : "");
+    S9sFormat      providerFormat(useColors ? "\033[94m" : "", useColors ? TERM_NORMAL : "");
+    S9sFormat      regionFormat(useColors ? "\033[33m" : "", useColors ? TERM_NORMAL : "");
+    S9sFormat      commentFormat(useColors ? "\033[1m\033[97m" : "", useColors ? TERM_NORMAL : "");
+    S9sFormat      endpointFormat(useColors ? "\033[1m\033[97m" : "", useColors ? TERM_NORMAL : "");
 
     // set width
     for (const auto & provider : reqResults)


### PR DESCRIPTION
I needed to use --color=never for some scripts