### PR TITLE
Fix pool-controllers --assignment docs and help text

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,4 +74,5 @@ debian/libs9s0/
 debian/s9s-tools.substvars
 debian/s9s-tools/
 debian/tmp/
+.idea/
 

--- a/doc/s9s-pool-controllers.1
+++ b/doc/s9s-pool-controllers.1
@@ -30,8 +30,9 @@ SID ID  HOSTNAME    PORT STATUS ROLE CLUSTERS
 .fi
 
 .TP
-.B --assigned-controller
-Gets existing controller assigned to provided cluster. Providing '--cluster-id' is mandatory
+.B --assignment
+Gets existing controller assigned to provided cluster. Providing '--cluster-id' is mandatory.
+Note: this operation is only available under the \fBpool-controllers\fP subcommand, not under \fBcontroller\fP.
 .nf
 s9s pool-controllers --assignment --cluster-id="2"
 SID ID  HOSTNAME    PORT STATUS ROLE CLUSTERS                    

--- a/libs9s/s9soptions.cpp
+++ b/libs9s/s9soptions.cpp
@@ -5414,8 +5414,8 @@ S9sOptions::isPrintDeploymentInfoRequested() const
 }
 
 /**
- * \returns true if the "assigned_controller" function is requested by providing the --assigned-controller
- *   command line option.
+ * \returns true if the "assignedController" operation is requested by providing the --assignment
+ *   command line option on the "pool-controllers" subcommand.
  */
 bool
 S9sOptions::isAssignedController() const
@@ -8781,11 +8781,11 @@ S9sOptions::printHelpControllers()
     printHelpGeneric();
 
     printf(
-"Options for the \"controllers\" command:\n"
+"Options for the \"pool-controllers\" command:\n"
 "  --list                     To retrieve the list of stored controllers.\n"
 "  --print-deployment-info    Print all controllers, including static deployment info.\n"
 "  --add-controller           To create a new controller instance on specified host.\n"
-"  --assigned-controller      To retrieve the controller assigned to specific cluster.\n"
+"  --assignment               To retrieve the controller assigned to specific cluster (requires --cluster-id).\n"
 "  --start                    To start a controller (requires --controller-id).\n"
 "  --stop                     To stop a controller (requires --controller-id).\n"
 "  --remove-controller        To remove a controller (requires --controller-id).\n"


### PR DESCRIPTION
## Summary
- Manpage `doc/s9s-pool-controllers.1` heading now uses the real flag `--assignment` (was `--assigned-controller`) and explicitly notes that the operation lives under `pool-controllers`, not `controller`.
- `printHelpControllers()` banner fixed to say `pool-controllers` (was `controllers`) and the listed flag matches the real CLI option (`--assignment`).
- Doxygen comment on `S9sOptions::isAssignedController()` updated accordingly.
- Added `.idea/` to `.gitignore`.

## Test plan
- [ ] `man s9s-pool-controllers` renders the updated section with `--assignment`.
- [ ] `s9s pool-controllers --help` header reads `Options for the "pool-controllers" command:` and lists `--assignment`.
- [ ] `s9s pool-controllers --assignment --cluster-id=<id>` still resolves the assigned controller (no behavioral change expected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)