### PR TITLE
Clus 7019 custom pghba

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,9 +1,0 @@
-{
-  "permissions": {
-    "allow": [
-      "mcp__claude_ai_Atlassian__getJiraIssue",
-      "Read(//Users/pablopnn/workspace/s9s/worktrees/**)",
-      "Read(//Users/pablopnn/workspace/**)"
-    ]
-  }
-}

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,9 @@
+{
+  "permissions": {
+    "allow": [
+      "mcp__claude_ai_Atlassian__getJiraIssue",
+      "Read(//Users/pablopnn/workspace/s9s/worktrees/**)",
+      "Read(//Users/pablopnn/workspace/**)"
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -75,4 +75,5 @@ debian/s9s-tools.substvars
 debian/s9s-tools/
 debian/tmp/
 .idea/
+.claude/
 

--- a/libs9s/s9soptions.cpp
+++ b/libs9s/s9soptions.cpp
@@ -3558,7 +3558,7 @@ S9sOptions::appendPgHbaRules(
             if (parts[0].toString().toLower() != "local")
                 return false;
 
-            rule["type"]     = parts[0].toString();
+            rule["type"]     = parts[0].toString().toLower();
             rule["database"] = parts[1].toString();
             rule["user"]     = parts[2].toString();
             rule["address"]  = "";
@@ -3569,7 +3569,7 @@ S9sOptions::appendPgHbaRules(
             if (parts[0].toString().toLower() == "local")
                 return false;
 
-            rule["type"]     = parts[0].toString();
+            rule["type"]     = parts[0].toString().toLower();
             rule["database"] = parts[1].toString();
             rule["user"]     = parts[2].toString();
             rule["address"]  = parts[3].toString();

--- a/libs9s/s9soptions.cpp
+++ b/libs9s/s9soptions.cpp
@@ -544,7 +544,9 @@ enum S9sOptionType
 
     OptionExtensions,
     OptionPgHbaRules,
-    OptionPgHbaTemplate
+    OptionPgHbaPreset,
+    OptionSaveAsHbaPreset,
+    OptionHbaPresetName
 };
 
 /**
@@ -3497,12 +3499,30 @@ S9sOptions::extensions() const
 }
 
 /**
- * \returns The value for the --pghba-template= command line option.
+ * \returns The value for the --pghba-preset= command line option.
  */
 S9sString
-S9sOptions::pgHbaTemplate() const
+S9sOptions::pgHbaPreset() const
 {
-    return getString("pghba_template");
+    return getString("pghba_preset");
+}
+
+/**
+ * \returns True if the --save-as-hba-preset flag was provided.
+ */
+bool
+S9sOptions::saveAsHbaPreset() const
+{
+    return getBool("save_as_hba_preset");
+}
+
+/**
+ * \returns The value for the --hba-preset-name= command line option.
+ */
+S9sString
+S9sOptions::hbaPresetName() const
+{
+    return getString("hba_preset_name");
 }
 
 S9sVariantList
@@ -8317,9 +8337,12 @@ S9sOptions::printHelpCluster()
 "                             Format: \"type database user address method\"\n"
 "                             Semicolon-separated for multiple rules.\n"
 "                             Example: \"host all myuser 192.168.1.0/24 md5\"\n"
-"  --pghba-template=FILENAME  pg_hba.conf template file (PostgreSQL deployment).\n"
+"  --pghba-preset=FILENAME    pg_hba.conf preset file to apply at deployment.\n"
 "                             File must exist in /etc/cmon/templates/ or\n"
 "                             /usr/share/cmon/templates/ on the controller.\n"
+"  --save-as-hba-preset       Save --pghba-rules as a reusable preset file.\n"
+"  --hba-preset-name=NAME     Filename stem for the saved preset (requires\n"
+"                             --save-as-hba-preset and --pghba-rules).\n"
 "  --firewalls=LIST           ID of the firewalls of the new container.\n"
 "  --generate-key             Generate an SSH key when creating containers.\n"
 "  --image=NAME               The name of the image for the container.\n"
@@ -15182,9 +15205,11 @@ S9sOptions::readOptionsCluster(
         { "keep-firewall",    no_argument,       0, OptionKeepFirewall     },
         { "volumes",          required_argument, 0, OptionVolumes          },
         { "extensions",       required_argument, 0, OptionExtensions       },
-        { "pghba-rules",      required_argument, 0, OptionPgHbaRules       },
-        { "pghba-template",   required_argument, 0, OptionPgHbaTemplate    },
-        { "vpc-id",           required_argument, 0, OptionVpcId            },
+        { "pghba-rules",        required_argument, 0, OptionPgHbaRules      },
+        { "pghba-preset",       required_argument, 0, OptionPgHbaPreset     },
+        { "save-as-hba-preset", no_argument,       0, OptionSaveAsHbaPreset },
+        { "hba-preset-name",    required_argument, 0, OptionHbaPresetName   },
+        { "vpc-id",             required_argument, 0, OptionVpcId           },
         { "template",         required_argument, 0, OptionTemplate         },
         
         { "with-ssl",         no_argument,       0, OptionWithSsl          },
@@ -16119,9 +16144,19 @@ S9sOptions::readOptionsCluster(
                 }
                 break;
 
-            case OptionPgHbaTemplate:
-                // --pghba-template=FILENAME
-                m_options["pghba_template"] = optarg;
+            case OptionPgHbaPreset:
+                // --pghba-preset=FILENAME
+                m_options["pghba_preset"] = optarg;
+                break;
+
+            case OptionSaveAsHbaPreset:
+                // --save-as-hba-preset
+                m_options["save_as_hba_preset"] = true;
+                break;
+
+            case OptionHbaPresetName:
+                // --hba-preset-name=NAME
+                m_options["hba_preset_name"] = optarg;
                 break;
 
             case OptionVpcId:

--- a/libs9s/s9soptions.cpp
+++ b/libs9s/s9soptions.cpp
@@ -3536,7 +3536,8 @@ S9sOptions::pgHbaRules() const
 /**
  * Parses --pghba-rules entries using pg_hba.conf native space-separated format.
  * Multiple rules are semicolon-separated.
- * Format: "type database user [address] method" — 4 or 5 space-separated tokens.
+ * local rules:      "local database user method"             (4 tokens, no address)
+ * all other types:  "type database user address method"      (5 tokens)
  * Example: "host all viafirma 192.168.201.0/24 md5;local all all trust"
  */
 bool
@@ -3564,6 +3565,10 @@ S9sOptions::appendPgHbaRules(
             rule["method"]   = parts[3].toString();
         } else if (parts.size() == 5)
         {
+            // local connections never carry an address field
+            if (parts[0].toString().toLower() == "local")
+                return false;
+
             rule["type"]     = parts[0].toString();
             rule["database"] = parts[1].toString();
             rule["user"]     = parts[2].toString();

--- a/libs9s/s9soptions.cpp
+++ b/libs9s/s9soptions.cpp
@@ -3549,11 +3549,14 @@ S9sOptions::appendPgHbaRules(
     for (uint idx = 0u; idx < entries.size(); ++idx)
     {
         S9sString      entryString = entries[idx].toString().trim();
-        S9sVariantList parts       = entryString.split(" ");
+        S9sVariantList parts       = entryString.split(" \t");
         S9sVariantMap  rule;
 
         if (parts.size() == 4)
         {
+            if (parts[0].toString().toLower() != "local")
+                return false;
+
             rule["type"]     = parts[0].toString();
             rule["database"] = parts[1].toString();
             rule["user"]     = parts[2].toString();
@@ -8335,6 +8338,7 @@ S9sOptions::printHelpCluster()
 "  --extensions=LIST          PostgresSQL extensions (postgis, pgvector).\n"
 "  --pghba-rules=LIST         Custom pg_hba.conf entries (PostgreSQL deployment).\n"
 "                             Format: \"type database user address method\"\n"
+"                             Local connections: \"local database user method\"\n"
 "                             Semicolon-separated for multiple rules.\n"
 "                             Example: \"host all myuser 192.168.1.0/24 md5\"\n"
 "  --pghba-preset=FILENAME    pg_hba.conf preset file to apply at deployment.\n"
@@ -16141,6 +16145,7 @@ S9sOptions::readOptionsCluster(
                 {
                     PRINT_ERROR("Invalid argument for --pghba-rules.");
                     m_exitStatus = BadOptions;
+                    return false;
                 }
                 break;
 

--- a/libs9s/s9soptions.cpp
+++ b/libs9s/s9soptions.cpp
@@ -543,7 +543,8 @@ enum S9sOptionType
     OptionUpdateCmon,
 
     OptionExtensions,
-    OptionPgHbaRules
+    OptionPgHbaRules,
+    OptionPgHbaTemplate
 };
 
 /**
@@ -3493,6 +3494,15 @@ S9sString
 S9sOptions::extensions() const
 {
     return getString("extensions");
+}
+
+/**
+ * \returns The value for the --pghba-template= command line option.
+ */
+S9sString
+S9sOptions::pgHbaTemplate() const
+{
+    return getString("pghba_template");
 }
 
 S9sVariantList
@@ -8307,6 +8317,9 @@ S9sOptions::printHelpCluster()
 "                             Format: \"type database user address method\"\n"
 "                             Semicolon-separated for multiple rules.\n"
 "                             Example: \"host all myuser 192.168.1.0/24 md5\"\n"
+"  --pghba-template=FILENAME  pg_hba.conf template file (PostgreSQL deployment).\n"
+"                             File must exist in /etc/cmon/templates/ or\n"
+"                             /usr/share/cmon/templates/ on the controller.\n"
 "  --firewalls=LIST           ID of the firewalls of the new container.\n"
 "  --generate-key             Generate an SSH key when creating containers.\n"
 "  --image=NAME               The name of the image for the container.\n"
@@ -15170,6 +15183,7 @@ S9sOptions::readOptionsCluster(
         { "volumes",          required_argument, 0, OptionVolumes          },
         { "extensions",       required_argument, 0, OptionExtensions       },
         { "pghba-rules",      required_argument, 0, OptionPgHbaRules       },
+        { "pghba-template",   required_argument, 0, OptionPgHbaTemplate    },
         { "vpc-id",           required_argument, 0, OptionVpcId            },
         { "template",         required_argument, 0, OptionTemplate         },
         
@@ -16103,6 +16117,11 @@ S9sOptions::readOptionsCluster(
                     PRINT_ERROR("Invalid argument for --pghba-rules.");
                     m_exitStatus = BadOptions;
                 }
+                break;
+
+            case OptionPgHbaTemplate:
+                // --pghba-template=FILENAME
+                m_options["pghba_template"] = optarg;
                 break;
 
             case OptionVpcId:

--- a/libs9s/s9soptions.cpp
+++ b/libs9s/s9soptions.cpp
@@ -542,7 +542,8 @@ enum S9sOptionType
     OptionRemoveController,
     OptionUpdateCmon,
 
-    OptionExtensions
+    OptionExtensions,
+    OptionPgHbaRules
 };
 
 /**
@@ -3493,6 +3494,59 @@ S9sOptions::extensions() const
 {
     return getString("extensions");
 }
+
+S9sVariantList
+S9sOptions::pgHbaRules() const
+{
+    if (m_options.contains("pghba_rules"))
+        return m_options.at("pghba_rules").toVariantList();
+    return S9sVariantList();
+}
+
+/**
+ * Parses --pghba-rules entries using pg_hba.conf native space-separated format.
+ * Multiple rules are semicolon-separated.
+ * Format: "type database user [address] method" — 4 or 5 space-separated tokens.
+ * Example: "host all viafirma 192.168.201.0/24 md5;local all all trust"
+ */
+bool
+S9sOptions::appendPgHbaRules(
+        const S9sString &stringRep)
+{
+    S9sVariantList entries    = stringRep.split(";");
+    S9sVariantList rulesToSet = pgHbaRules();
+
+    for (uint idx = 0u; idx < entries.size(); ++idx)
+    {
+        S9sString      entryString = entries[idx].toString().trim();
+        S9sVariantList parts       = entryString.split(" ");
+        S9sVariantMap  rule;
+
+        if (parts.size() == 4)
+        {
+            rule["type"]     = parts[0].toString();
+            rule["database"] = parts[1].toString();
+            rule["user"]     = parts[2].toString();
+            rule["address"]  = "";
+            rule["method"]   = parts[3].toString();
+        } else if (parts.size() == 5)
+        {
+            rule["type"]     = parts[0].toString();
+            rule["database"] = parts[1].toString();
+            rule["user"]     = parts[2].toString();
+            rule["address"]  = parts[3].toString();
+            rule["method"]   = parts[4].toString();
+        } else {
+            return false;
+        }
+
+        rulesToSet << rule;
+    }
+
+    m_options["pghba_rules"] = rulesToSet;
+    return true;
+}
+
 /**
  *
  * \code{.js}
@@ -8249,6 +8303,10 @@ S9sOptions::printHelpCluster()
 "  --db-owner=NAME            The owner of the database. PostgreSQL only.\n"
 "  --donor=ADDRESS            The address of the donor node when starting.\n"
 "  --extensions=LIST          PostgresSQL extensions (postgis, pgvector).\n"
+"  --pghba-rules=LIST         Custom pg_hba.conf entries (PostgreSQL deployment).\n"
+"                             Format: \"type database user address method\"\n"
+"                             Semicolon-separated for multiple rules.\n"
+"                             Example: \"host all myuser 192.168.1.0/24 md5\"\n"
 "  --firewalls=LIST           ID of the firewalls of the new container.\n"
 "  --generate-key             Generate an SSH key when creating containers.\n"
 "  --image=NAME               The name of the image for the container.\n"
@@ -15111,6 +15169,7 @@ S9sOptions::readOptionsCluster(
         { "keep-firewall",    no_argument,       0, OptionKeepFirewall     },
         { "volumes",          required_argument, 0, OptionVolumes          },
         { "extensions",       required_argument, 0, OptionExtensions       },
+        { "pghba-rules",      required_argument, 0, OptionPgHbaRules       },
         { "vpc-id",           required_argument, 0, OptionVpcId            },
         { "template",         required_argument, 0, OptionTemplate         },
         
@@ -16035,6 +16094,15 @@ S9sOptions::readOptionsCluster(
             case OptionExtensions:
                     // --extensions=STRING
                 m_options["extensions"] = optarg;
+                break;
+
+            case OptionPgHbaRules:
+                // --pghba-rules=STRING
+                if (!appendPgHbaRules(optarg))
+                {
+                    PRINT_ERROR("Invalid argument for --pghba-rules.");
+                    m_exitStatus = BadOptions;
+                }
                 break;
 
             case OptionVpcId:

--- a/libs9s/s9soptions.h
+++ b/libs9s/s9soptions.h
@@ -420,7 +420,9 @@ class S9sOptions
         bool createLocalRepo() const;
         bool keepFirewall() const;
         S9sString extensions() const;
-        S9sString pgHbaTemplate() const;
+        S9sString pgHbaPreset() const;
+        bool saveAsHbaPreset() const;
+        S9sString hbaPresetName() const;
         S9sVariantList pgHbaRules() const;
         bool appendPgHbaRules(const S9sString &stringRep);
 

--- a/libs9s/s9soptions.h
+++ b/libs9s/s9soptions.h
@@ -420,6 +420,8 @@ class S9sOptions
         bool createLocalRepo() const;
         bool keepFirewall() const;
         S9sString extensions() const;
+        S9sVariantList pgHbaRules() const;
+        bool appendPgHbaRules(const S9sString &stringRep);
 
         bool uninstall() const;
         bool unregisterOnly() const;

--- a/libs9s/s9soptions.h
+++ b/libs9s/s9soptions.h
@@ -420,6 +420,7 @@ class S9sOptions
         bool createLocalRepo() const;
         bool keepFirewall() const;
         S9sString extensions() const;
+        S9sString pgHbaTemplate() const;
         S9sVariantList pgHbaRules() const;
         bool appendPgHbaRules(const S9sString &stringRep);
 

--- a/libs9s/s9srpcclient.cpp
+++ b/libs9s/s9srpcclient.cpp
@@ -4432,11 +4432,10 @@ S9sRpcClient::createPostgreSql(
         return false;
     }
 
-    if (options->saveAsHbaPreset() && options->pgHbaRules().empty()
-            && options->pgHbaPreset().empty())
+    if (options->saveAsHbaPreset() && options->pgHbaRules().empty())
     {
         PRINT_ERROR(
-            "--save-as-hba-preset requires --pghba-rules or --pghba-preset.");
+            "--save-as-hba-preset requires --pghba-rules.");
         options->setExitStatus(S9sOptions::BadOptions);
         return false;
     }

--- a/libs9s/s9srpcclient.cpp
+++ b/libs9s/s9srpcclient.cpp
@@ -4424,6 +4424,23 @@ S9sRpcClient::createPostgreSql(
         return false;
     }
 
+    if (!options->hbaPresetName().empty() && !options->saveAsHbaPreset())
+    {
+        PRINT_ERROR(
+            "--hba-preset-name requires --save-as-hba-preset.");
+        options->setExitStatus(S9sOptions::BadOptions);
+        return false;
+    }
+
+    if (options->saveAsHbaPreset() && options->pgHbaRules().empty()
+            && options->pgHbaPreset().empty())
+    {
+        PRINT_ERROR(
+            "--save-as-hba-preset requires --pghba-rules or --pghba-preset.");
+        options->setExitStatus(S9sOptions::BadOptions);
+        return false;
+    }
+
     addCredentialsToJobData(jobData);
 
     // 

--- a/libs9s/s9srpcclient.cpp
+++ b/libs9s/s9srpcclient.cpp
@@ -4444,8 +4444,14 @@ S9sRpcClient::createPostgreSql(
     if (!options->extensions().empty())
         jobData["pg_extensions"]     = options->extensions();
 
-    if (!options->pgHbaTemplate().empty())
-        jobData["hba_template"]      = options->pgHbaTemplate();
+    if (!options->pgHbaPreset().empty())
+        jobData["hba_preset"]        = options->pgHbaPreset();
+
+    if (options->saveAsHbaPreset())
+        jobData["save_as_hba_preset"] = true;
+
+    if (!options->hbaPresetName().empty())
+        jobData["hba_preset_name"]   = options->hbaPresetName();
 
     if (!options->pgHbaRules().empty())
         jobData["extra_hba_rules"]   = options->pgHbaRules();

--- a/libs9s/s9srpcclient.cpp
+++ b/libs9s/s9srpcclient.cpp
@@ -4444,6 +4444,9 @@ S9sRpcClient::createPostgreSql(
     if (!options->extensions().empty())
         jobData["pg_extensions"]     = options->extensions();
 
+    if (!options->pgHbaTemplate().empty())
+        jobData["hba_template"]      = options->pgHbaTemplate();
+
     if (!options->pgHbaRules().empty())
         jobData["extra_hba_rules"]   = options->pgHbaRules();
 

--- a/libs9s/s9srpcclient.cpp
+++ b/libs9s/s9srpcclient.cpp
@@ -4443,7 +4443,10 @@ S9sRpcClient::createPostgreSql(
     jobData["deploy_agents"]    = !options->noAgent();
     if (!options->extensions().empty())
         jobData["pg_extensions"]     = options->extensions();
-    
+
+    if (!options->pgHbaRules().empty())
+        jobData["extra_hba_rules"]   = options->pgHbaRules();
+
     if (options->withTimescaleDb())
         jobData["install_timescaledb"] = true;
     

--- a/tests/ut_s9srpcclient/ut_s9srpcclient.cpp
+++ b/tests/ut_s9srpcclient/ut_s9srpcclient.cpp
@@ -1054,19 +1054,51 @@ UtS9sRpcClient::testCreateCluster04()
             payload.valueByPath(JOB_DATA "version").toString(),
             "myversion");
 
-    // Test hba_template is passed when pghba_template option is set.
+    // Test hba_preset is passed when pghba_preset option is set.
     {
-        options->m_options["pghba_template"] = "my_hba_template.conf";
+        options->m_options["pghba_preset"] = "my_hba_preset.conf";
 
         S9S_VERIFY(client.createCluster());
         payload = client.lastPayload();
 
         S9S_COMPARE(
                 payload.valueByPath(
-                    JOB_DATA "hba_template").toString(),
-                "my_hba_template.conf");
+                    JOB_DATA "hba_preset").toString(),
+                "my_hba_preset.conf");
 
-        options->m_options.erase("pghba_template");
+        options->m_options.erase("pghba_preset");
+    }
+
+    // Test save_as_hba_preset and hba_preset_name are passed when set.
+    {
+        S9sVariantMap rule;
+        S9sVariantList rules;
+
+        rule["type"]     = "host";
+        rule["database"] = "all";
+        rule["user"]     = "save_preset_user";
+        rule["address"]  = "192.0.2.0/24";
+        rule["method"]   = "md5";
+        rules << rule;
+        options->m_options["pghba_rules"]        = rules;
+        options->m_options["save_as_hba_preset"] = true;
+        options->m_options["hba_preset_name"]    = "viafirma";
+
+        S9S_VERIFY(client.createCluster());
+        payload = client.lastPayload();
+
+        S9S_COMPARE(
+                payload.valueByPath(
+                    JOB_DATA "save_as_hba_preset").toBoolean(),
+                true);
+        S9S_COMPARE(
+                payload.valueByPath(
+                    JOB_DATA "hba_preset_name").toString(),
+                "viafirma");
+
+        options->m_options.erase("pghba_rules");
+        options->m_options.erase("save_as_hba_preset");
+        options->m_options.erase("hba_preset_name");
     }
 
     // Test extra_hba_rules is passed when pghba_rules option is set.

--- a/tests/ut_s9srpcclient/ut_s9srpcclient.cpp
+++ b/tests/ut_s9srpcclient/ut_s9srpcclient.cpp
@@ -1125,6 +1125,8 @@ UtS9sRpcClient::testCreateCluster04()
         S9S_COMPARE(firstRule["user"].toString(),    "viafirma");
         S9S_COMPARE(firstRule["address"].toString(), "192.168.201.0/24");
         S9S_COMPARE(firstRule["method"].toString(),  "md5");
+
+        options->m_options.erase("pghba_rules");
     }
 
     return true;

--- a/tests/ut_s9srpcclient/ut_s9srpcclient.cpp
+++ b/tests/ut_s9srpcclient/ut_s9srpcclient.cpp
@@ -1103,16 +1103,7 @@ UtS9sRpcClient::testCreateCluster04()
 
     // Test extra_hba_rules is passed when pghba_rules option is set.
     {
-        S9sVariantMap  rule;
-        S9sVariantList rules;
-
-        rule["type"]     = "host";
-        rule["database"] = "all";
-        rule["user"]     = "viafirma";
-        rule["address"]  = "192.168.201.0/24";
-        rule["method"]   = "md5";
-        rules << rule;
-        options->m_options["pghba_rules"] = rules;
+        S9S_VERIFY(options->appendPgHbaRules("host all viafirma 192.168.201.0/24 md5"));
 
         S9S_VERIFY(client.createCluster());
         payload = client.lastPayload();

--- a/tests/ut_s9srpcclient/ut_s9srpcclient.cpp
+++ b/tests/ut_s9srpcclient/ut_s9srpcclient.cpp
@@ -1117,22 +1117,14 @@ UtS9sRpcClient::testCreateCluster04()
         S9S_VERIFY(client.createCluster());
         payload = client.lastPayload();
 
-        S9S_COMPARE(
-                payload.valueByPath(
-                    JOB_DATA "extra_hba_rules[0]/type").toString(),
-                "host");
-        S9S_COMPARE(
-                payload.valueByPath(
-                    JOB_DATA "extra_hba_rules[0]/user").toString(),
-                "viafirma");
-        S9S_COMPARE(
-                payload.valueByPath(
-                    JOB_DATA "extra_hba_rules[0]/address").toString(),
-                "192.168.201.0/24");
-        S9S_COMPARE(
-                payload.valueByPath(
-                    JOB_DATA "extra_hba_rules[0]/method").toString(),
-                "md5");
+        S9sVariantList hbaRules =
+            payload.valueByPath(JOB_DATA "extra_hba_rules").toVariantList();
+        S9S_COMPARE(hbaRules.size(), 1u);
+        S9sVariantMap firstRule = hbaRules[0].toVariantMap();
+        S9S_COMPARE(firstRule["type"].toString(),    "host");
+        S9S_COMPARE(firstRule["user"].toString(),    "viafirma");
+        S9S_COMPARE(firstRule["address"].toString(), "192.168.201.0/24");
+        S9S_COMPARE(firstRule["method"].toString(),  "md5");
     }
 
     return true;

--- a/tests/ut_s9srpcclient/ut_s9srpcclient.cpp
+++ b/tests/ut_s9srpcclient/ut_s9srpcclient.cpp
@@ -1119,7 +1119,7 @@ UtS9sRpcClient::testCreateCluster04()
 
         S9sVariantList hbaRules =
             payload.valueByPath(JOB_DATA "extra_hba_rules").toVariantList();
-        S9S_COMPARE(hbaRules.size(), 1u);
+        S9S_COMPARE(hbaRules.size(), 1);
         S9sVariantMap firstRule = hbaRules[0].toVariantMap();
         S9S_COMPARE(firstRule["type"].toString(),    "host");
         S9S_COMPARE(firstRule["user"].toString(),    "viafirma");

--- a/tests/ut_s9srpcclient/ut_s9srpcclient.cpp
+++ b/tests/ut_s9srpcclient/ut_s9srpcclient.cpp
@@ -1054,6 +1054,21 @@ UtS9sRpcClient::testCreateCluster04()
             payload.valueByPath(JOB_DATA "version").toString(),
             "myversion");
 
+    // Test hba_template is passed when pghba_template option is set.
+    {
+        options->m_options["pghba_template"] = "my_hba_template.conf";
+
+        S9S_VERIFY(client.createCluster());
+        payload = client.lastPayload();
+
+        S9S_COMPARE(
+                payload.valueByPath(
+                    JOB_DATA "hba_template").toString(),
+                "my_hba_template.conf");
+
+        options->m_options.erase("pghba_template");
+    }
+
     // Test extra_hba_rules is passed when pghba_rules option is set.
     {
         S9sVariantMap  rule;

--- a/tests/ut_s9srpcclient/ut_s9srpcclient.cpp
+++ b/tests/ut_s9srpcclient/ut_s9srpcclient.cpp
@@ -1054,6 +1054,40 @@ UtS9sRpcClient::testCreateCluster04()
             payload.valueByPath(JOB_DATA "version").toString(),
             "myversion");
 
+    // Test extra_hba_rules is passed when pghba_rules option is set.
+    {
+        S9sVariantMap  rule;
+        S9sVariantList rules;
+
+        rule["type"]     = "host";
+        rule["database"] = "all";
+        rule["user"]     = "viafirma";
+        rule["address"]  = "192.168.201.0/24";
+        rule["method"]   = "md5";
+        rules << rule;
+        options->m_options["pghba_rules"] = rules;
+
+        S9S_VERIFY(client.createCluster());
+        payload = client.lastPayload();
+
+        S9S_COMPARE(
+                payload.valueByPath(
+                    JOB_DATA "extra_hba_rules[0]/type").toString(),
+                "host");
+        S9S_COMPARE(
+                payload.valueByPath(
+                    JOB_DATA "extra_hba_rules[0]/user").toString(),
+                "viafirma");
+        S9S_COMPARE(
+                payload.valueByPath(
+                    JOB_DATA "extra_hba_rules[0]/address").toString(),
+                "192.168.201.0/24");
+        S9S_COMPARE(
+                payload.valueByPath(
+                    JOB_DATA "extra_hba_rules[0]/method").toString(),
+                "md5");
+    }
+
     return true;
 }
 


### PR DESCRIPTION
## Summary

- Add `--pghba-rules` flag to inject custom `pg_hba.conf` entries (as structured `extra_hba_rules` objects) during PostgreSQL cluster deployment
- Add `--pghba-preset` flag to apply a pre-existing pg_hba.conf template file from the controller; the controller searches `/etc/cmon/templates/` first, then falls back to `/usr/share/cmon/templates/`
- Add `--save-as-hba-preset` + `--hba-preset-name` flags to persist the inline `--pghba-rules` as a reusable preset file saved to `/etc/cmon/templates/` on the controller at deploy time

Keeps s9s-tools in sync with the matching `clustercontrol-enterprise` changes on branch `clus-7019-custom-pghba`.

## Job data fields

| CLI flag | job_data field | Type |
|---|---|---|
| `--pghba-rules="type db user addr method[;...]"` | `extra_hba_rules` | array of objects |
| `--pghba-preset=FILENAME` | `hba_preset` | string |
| `--save-as-hba-preset` | `save_as_hba_preset` | bool |
| `--hba-preset-name=NAME` | `hba_preset_name` | string |

## Test plan

- [ ] `tests/ut_s9srpcclient/ut_s9srpcclient` — `testCreateCluster04` covers all four new job fields in the RPC payload
- [ ] Manual: `s9s cluster --create --cluster-type=postgresql --pghba-rules="host all viafirma 192.168.201.0/24 md5" ...`

Jira: https://severalnines.atlassian.net/browse/CLUS-7019

🤖 Generated with [Claude Code](https://claude.com/claude-code)