### PR TITLE
CLUS-7119: ClickHouse: accept node protocols

### DIFF
--- a/libs9s/s9snode.cpp
+++ b/libs9s/s9snode.cpp
@@ -134,8 +134,7 @@ S9sNode::S9sNode(
             m_properties["class_name"] = "CmonElasticHost";
         else if (m_url.protocol().toLower() == "clickhouse")
             m_properties["class_name"] = "CmonClickHouseHost";
-        else if (m_url.protocol().toLower() == "clickhouse_keeper"
-              || m_url.protocol().toLower() == "clickhouse-keeper")
+        else if (m_url.protocol().toLower() == "clickhouse-keeper")
         {
             m_properties["class_name"] = "CmonClickHouseHost";
             m_properties["nodetype"] = "clickhouse_keeper";

--- a/libs9s/s9srpcclient.cpp
+++ b/libs9s/s9srpcclient.cpp
@@ -5315,6 +5315,8 @@ S9sRpcClient::createNode()
         } else if (protocol == "elastic")
         {            
             hasElastic = true;
+        } else if (protocol == "clickhouse" || protocol == "clickhouse-keeper")
+        {
         } else if (protocol.empty())
         {
         } else {


### PR DESCRIPTION
This PR adds support for ClickHouse add-node protocols, accepting `clickhouse://` data nodes and `clickhouse-keeper://` dedicated Keeper nodes.