### PR TITLE
CLUS-7448: Read and display error_id from RPC responses

### DIFF
--- a/doc/s9s-pool-controllers.1
+++ b/doc/s9s-pool-controllers.1
@@ -135,3 +135,29 @@ Controller version to be installed.
 .TP
 .B \-\^\-uninstall
 When used with \fB--remove-controller\fP, this option will also uninstall the controller software from the host. Without this option, the controller is only unregistered from the pool but the software remains installed.
+
+.\"
+.\"
+.\"
+.SH ERRORS
+When a request is routed to the wrong controller in a pool the reply will contain
+.B error_id: 1
+.RB ( ClusterNotAssignedToController ).
+This means the cluster is assigned to a different controller and the caller should
+refresh its controller-cluster map and retry the request against the correct controller.
+
+.nf
+{
+    "error_id": 1,
+    "error_string": "Request aborted. Cluster 3 is not assigned to the controller.",
+    "request_status": "ObjectNotFound"
+}
+.fi
+
+See
+.BR s9s (1)
+section
+.B ERROR IDS
+for the full list of
+.B error_id
+values.

--- a/doc/s9s.1
+++ b/doc/s9s.1
@@ -216,6 +216,50 @@ and print more messages.
 .\"
 .\"
 .\"
+.SH ERROR IDS
+RPC replies from the controller may include an
+.B error_id
+integer field alongside the human-readable
+.B error_string
+and the
+.B request_status
+code.
+The field is absent when no specific error condition applies (successful replies and generic errors).
+Automated clients should use
+.B error_id
+for branching logic instead of parsing
+.BR error_string ,
+which is subject to change.
+
+.TS
+tab(|) allbox;
+cb cb cb
+n l l.
+Value|Name|Recovery
+1|ClusterNotAssignedToController|Cluster is managed by a different controller \(em refresh the controller-cluster map and retry
+2|AuthenticationRequired|Session missing or expired \(em re-authenticate
+3|InvalidCredentials|Wrong username or password \(em check credentials
+4|LicenseRequired|Operation blocked by missing or invalid license
+5|ControllerInitializing|Controller is still starting up \(em retry after a short delay
+.TE
+
+.PP
+Example response with
+.B error_id
+set:
+
+.nf
+{
+    "controller_id": "10192",
+    "error_id": 3,
+    "error_string": "Username or password is incorrect.",
+    "request_status": "AccessDenied"
+}
+.fi
+
+.\"
+.\"
+.\"
 .SH EXAMPLES
 List the clusters and the nodes managed by the controller:
 

--- a/libs9s/s9srpcreply.cpp
+++ b/libs9s/s9srpcreply.cpp
@@ -178,6 +178,18 @@ S9sRpcReply::errorString() const
     return S9sString();
 }
 
+/**
+ * \returns The error_id sent by the controller in the reply, or 0 if not set.
+ */
+int
+S9sRpcReply::errorId() const
+{
+    if (contains("error_id"))
+        return at("error_id").toInt();
+
+    return 0;
+}
+
 S9sString
 S9sRpcReply::uuid() const
 {
@@ -1500,14 +1512,17 @@ S9sRpcReply::printMessages(
         }
     }
 
-    // And if error string is set, pint out it as well
+    // And if error string is set, print it out as well
     if (!errorString().empty())
     {
         if (isOk())
         {
             ::printf("%s\n", STR(S9sString::html2ansi(errorString())));
         } else {
-            PRINT_ERROR("%s", STR(errorString()));
+            if (errorId() != 0)
+                PRINT_ERROR("%s (error_id: %d)", STR(errorString()), errorId());
+            else
+                PRINT_ERROR("%s", STR(errorString()));
         }
     }
 }

--- a/libs9s/s9srpcreply.h
+++ b/libs9s/s9srpcreply.h
@@ -62,6 +62,7 @@ class S9sRpcReply : public S9sVariantMap
         bool isRedirect() const;
 
         S9sString errorString() const;
+        int errorId() const;
         S9sString uuid() const;
 
         S9sTreeNode tree();


### PR DESCRIPTION
## Summary

- Adds `errorId()` to `S9sRpcReply` — reads the new `error_id` integer field from JSON RPC responses (returns 0 when absent, so existing clients are unaffected)
- `printMessages()` appends `(error_id: N)` to error output when the field is non-zero, giving operators a stable machine-readable code alongside the human-readable `error_string`
- `doc/s9s.1`: new **ERROR IDS** section with the full value table (values 1–5), recovery guidance per value, and a JSON example
- `doc/s9s-pool-controllers.1`: new **ERRORS** section focused on `error_id: 1` (`ClusterNotAssignedToController`) — the primary pool-routing failure case

## Test plan

- [ ] Build passes (`make -j`)
- [ ] All unit tests pass (`tests/runalltests.sh`)
- [ ] `man doc/s9s.1` renders ERROR IDS table correctly
- [ ] `man doc/s9s-pool-controllers.1` renders ERRORS section correctly
- [ ] On a wrong-password login, output includes `(error_id: 3)` next to the error string

Closes CLUS-7448

🤖 Generated with [Claude Code](https://claude.com/claude-code)