### PR TITLE
CLUS-7607 NDB cluster --create: add --ndb-data-memory-ratio flag

### DIFF
--- a/libs9s/s9soptions.cpp
+++ b/libs9s/s9soptions.cpp
@@ -450,6 +450,7 @@ enum S9sOptionType
     OptionNoInstall,
     OptionMasterDelay,
     OptionNoTerminate,
+    OptionNdbDataMemoryRatio,
     OptionWithTimescaleDb,
     OptionUpgradeToVersion,
     OptionUpgradeMethod,
@@ -8291,6 +8292,11 @@ S9sOptions::printHelpCluster()
 "  --with-ssl                 Set up ssl while installing cluster.\n"
 "  --with-tags=LIST           Limit the list of printed clusters by tags.\n"
 "  --with-timescaledb         Enable TimescaleDb when the cluster is created.\n"
+"  --ndb-data-memory-ratio=RATIO\n"
+"                             For NDB cluster --create: fraction of host\n"
+"                             system memory used as auto DataMemory.\n"
+"                             Default 0.5. Persists into the cluster's\n"
+"                             cmon_N.cnf.\n"
 "  --uninstall                Uninstall software when removing a node.\n"
 
 "\n"
@@ -15065,6 +15071,8 @@ S9sOptions::readOptionsCluster(
         { "percona-pro-token", required_argument, 0, OptionPerconaProToken },
         { "with-database",    no_argument,       0, OptionWithDatabase    },
         { "with-timescaledb", no_argument,       0, OptionWithTimescaleDb },
+        { "ndb-data-memory-ratio",
+                              required_argument, 0, OptionNdbDataMemoryRatio },
         { "upgrade-to-version",required_argument, 0, OptionUpgradeToVersion },
         { "upgrade-method",   required_argument, 0, OptionUpgradeMethod   },
         { "delete-old-node",  no_argument,       0, OptionDeleteOldNode   },
@@ -15749,6 +15757,11 @@ S9sOptions::readOptionsCluster(
             case OptionWithTimescaleDb:
                 // --with-timescaledb
                 m_options["with_timescaledb"] = true;
+                break;
+
+            case OptionNdbDataMemoryRatio:
+                // --ndb-data-memory-ratio
+                m_options["ndb_data_memory_ratio"] = optarg;
                 break;
 
             case OptionUpgradeToVersion:

--- a/libs9s/s9srpcclient.cpp
+++ b/libs9s/s9srpcclient.cpp
@@ -4281,6 +4281,23 @@ S9sRpcClient::createNdbCluster(
     jobData["disable_firewall"] = !options->keepFirewall();
     jobData["deploy_agents"]    = !options->noAgent();
 
+    // --ndb-data-memory-ratio=RATIO -- forwarded to cmon as
+    // /job_data/ndb_data_memory_ratio so the auto-calculated NDB
+    // DataMemory can be tuned without resorting to an explicit absolute
+    // value. cmon also persists this into the per-cluster cmon_N.cnf
+    // (PropNdbDataMemoryRatio) so subsequent operations on the cluster
+    // re-use the same sizing.
+    {
+        const S9sString ratioStr = options->getString(
+                "ndb_data_memory_ratio", "");
+        if (!ratioStr.empty())
+        {
+            const double ratio = ratioStr.toDouble();
+            if (ratio > 0.0)
+                jobData["ndb_data_memory_ratio"] = ratio;
+        }
+    }
+
     if (options->hasRemoteClusterIdOption())
         jobData["remote_cluster_id"] = options->remoteClusterId();
     


### PR DESCRIPTION
> ***by AI agent on behalf of Peter Csaszar***

## Summary
- New `--ndb-data-memory-ratio=RATIO` flag on `s9s cluster --create --cluster-type=ndb`
- Forwards to cmon as `/job_data/ndb_data_memory_ratio`; cmon clamps the auto-DataMemory to `RATIO × systemMemory`
- Default behaviour unchanged: when the flag is absent and the matching cmon-side `ndb_data_memory_ratio` controller knob is not set, cmon falls back to the historical `0.5 × systemMemory` sizing
- Motivation: NDB tests under LXC/Docker (no memory cgroup limit) currently OOM because `/proc/meminfo` reports the host's RAM; the new flag lets operators say "use 5% instead" without resorting to an absolute MiB override via `/job_data/data_memory`
- Paired cmon-side change is on the `clustercontrol-enterprise` `CLUS-7607` branch (`PropNdbDataMemoryRatio` config item + create-time ratio resolution from `job_data` → `cmon.cnf` → built-in `0.5`)

## Test plan
- [ ] s9s build green on the unit-tests workflow
- [ ] `s9s cluster --create --cluster-type=ndb --help` shows `--ndb-data-memory-ratio=RATIO`
- [ ] `s9s cluster --create --cluster-type=ndb --nodes=... --ndb-data-memory-ratio=0.05` puts the value in the create job's `job_data`
- [ ] Once merged + published to s9s-tools-testing, switch `ft_ndb` / `ft_backup_ndb` / `ft_registerndb` (s9s-cmon-test CLUS-7607) to pass the flag per-create and drop the controller-wide fallback added to `create_cmon_config.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

> ***by AI agent on behalf of Peter Csaszar***