### PR TITLE
CLUS-7143: Register an existing ClickHouse cluster from the CLI

### DIFF
--- a/doc/s9s-cluster.1
+++ b/doc/s9s-cluster.1
@@ -479,6 +479,21 @@ s9s cluster \\
     --wait
 .fi
 
+An existing ClickHouse cluster can be registered by giving a single node endpoint.
+The controller discovers the remaining nodes and their roles.
+
+.B EXAMPLE
+.nf
+s9s cluster \\
+    --register \\
+    --cluster-type=clickhouse \\
+    --nodes=192.168.0.196 \\
+    --db-admin=default \\
+    --db-admin-passwd=secret \\
+    --cluster-name=clickhouse_001 \\
+    --wait
+.fi
+
 .TP
 .B \-\-remove\-node
 Removes a node from the cluster by creating a job that performs the removal.
@@ -1124,8 +1139,9 @@ supported:
 \fBmysqlreplication\fP,
 \fBgroupreplication\fP (or \fBgroup_replication\fP),
 \fBndb\fP (or \fBndbcluster\fP),
-\fBpostgresql\fP
-and \fBpostgresql_logical\fP.
+\fBpostgresql\fP,
+\fBpostgresql_logical\fP
+and \fBclickhouse\fP.
 
 .TP
 .BI --config-template= FILENAME

--- a/libs9s/s9srpcclient.cpp
+++ b/libs9s/s9srpcclient.cpp
@@ -3473,6 +3473,10 @@ S9sRpcClient::registerCluster()
     {
         success = registerElasticsearchCluster(hosts, osUserName);
     }
+    else if (options->clusterType() == "clickhouse")
+    {
+        success = registerClickHouseCluster(hosts, osUserName);
+    }
     else {
         PRINT_ERROR("Register cluster is currently not implemented for "
                 " cluster type '%s'.",
@@ -13522,6 +13526,65 @@ S9sRpcClient::registerElasticsearchCluster(
     //
     // The request describing we want to register a job instance.
     //
+    request["operation"]        = "createJobInstance";
+    request["job"]              = job;
+
+    return executeRequest(uri, request);
+}
+
+bool
+S9sRpcClient::registerClickHouseCluster(
+        const S9sVariantList &hosts,
+        const S9sString      &osUserName)
+{
+    S9sOptions     *options = S9sOptions::instance();
+    S9sVariantMap   request;
+    S9sVariantMap   job = composeJob();
+    S9sVariantMap   jobData = composeJobData();
+    S9sVariantMap   jobSpec;
+    S9sString       uri = "/v2/jobs/";
+
+    if (hosts.size() < 1u)
+    {
+        PRINT_ERROR("Node is not specified while registering existing cluster.");
+        return false;
+    }
+    else if (hosts.size() > 1u)
+    {
+
+        PRINT_ERROR("ClickHouse clusters requires only one cluster's node to discover topology");
+        return false;
+    }
+
+    addCredentialsToJobData(jobData);
+
+    //
+    // The job_data describing the cluster.
+    //
+    jobData["cluster_type"]     = "clickhouse";
+    jobData["type"]             = "clickhouse";
+    jobData["nodes"]            = nodesField(hosts);
+    
+    if (!options->clusterName().empty())
+        jobData["cluster_name"] = options->clusterName();
+
+    // Database credentials are optional for ClickHouse import.
+    // CMON uses them for the HTTP discovery queries and fails
+    // closed if the endpoint rejects them.
+    if (!options->dbAdminUserName().empty())
+        jobData["db_user"]      = options->dbAdminUserName();
+    if (!options->dbAdminPassword().empty())
+        jobData["db_password"]  = options->dbAdminPassword();
+
+    // The jobspec describing the command.
+    jobSpec["command"]          = "add_cluster";
+    jobSpec["job_data"]         = jobData;
+
+    // The job instance describing how the job will be executed.
+    job["title"]                = "Register ClickHouse Cluster";
+    job["job_spec"]             = jobSpec;
+
+    // The request describing we want to register a job instance.
     request["operation"]        = "createJobInstance";
     request["job"]              = job;
 

--- a/libs9s/s9srpcclient.h
+++ b/libs9s/s9srpcclient.h
@@ -652,6 +652,10 @@ class S9sRpcClient
                 const S9sVariantList &hosts,
                 const S9sString      &osUserName);
 
+        bool registerClickHouseCluster(
+                const S9sVariantList &hosts,
+                const S9sString      &osUserName);
+
         bool createMsSqlSingle(
                 const S9sVariantList &hosts,
                 const S9sString      &osUserName,

--- a/tests/ut_s9srpcclient/ut_s9srpcclient.cpp
+++ b/tests/ut_s9srpcclient/ut_s9srpcclient.cpp
@@ -124,6 +124,7 @@ UtS9sRpcClient::runTest(
     PERFORM_TEST(testCreateCluster04,     retval);
     PERFORM_TEST(testCreateCluster05,     retval);
     PERFORM_TEST(testCreateCluster06,     retval);
+    PERFORM_TEST(testRegisterClickHouse,  retval);
 
 
     PERFORM_TEST(testGetAllClusterInfo,   retval);
@@ -1158,6 +1159,64 @@ UtS9sRpcClient::testCreateCluster06()
     S9S_COMPARE(
             payload.valueByPath(JOB_DATA "version").toString(),
             "myversion");
+
+    return true;
+}
+
+bool
+UtS9sRpcClient::testRegisterClickHouse()
+{
+    S9sOptions         *options = S9sOptions::instance();
+    S9sRpcClientTester  client;
+    S9sVariantMap       payload;
+
+    options->m_options["cluster_type"]       = "clickhouse";
+    options->m_options["cluster_name"]       = "ch_001";
+    options->m_options["db_admin_user_name"] = "default";
+    options->m_options["db_admin_password"]  = "secret";
+    options->setNodes("NODE1:9440");
+
+    S9S_VERIFY(client.registerCluster());
+
+    payload = client.lastPayload();
+    if (isVerbose())
+        printDebug(payload);
+
+    S9S_COMPARE(client.uri(0), "/v2/jobs/");
+    S9S_COMPARE(payload["operation"].toString(), "createJobInstance");
+
+    S9S_COMPARE(
+            payload.valueByPath("/job/title").toString(),
+            "Register ClickHouse Cluster");
+
+    S9S_COMPARE(
+            payload.valueByPath("/job/job_spec/command").toString(),
+            "add_cluster");
+
+    S9S_COMPARE(
+            payload.valueByPath(JOB_DATA "cluster_type").toString(),
+            "clickhouse");
+
+    S9S_COMPARE(
+            payload.valueByPath(JOB_DATA "type").toString(),
+            "clickhouse");
+
+    S9S_COMPARE(
+            payload.valueByPath(JOB_DATA "cluster_name").toString(),
+            "ch_001");
+
+    S9S_COMPARE(
+            payload.valueByPath(JOB_DATA "db_user").toString(),
+            "default");
+
+    S9S_COMPARE(
+            payload.valueByPath(JOB_DATA "db_password").toString(),
+            "secret");
+
+    // Exactly one node was forwarded for topology discovery.
+    S9S_COMPARE(
+            payload.valueByPath(JOB_DATA "nodes").toVariantList().size(),
+            1);
 
     return true;
 }

--- a/tests/ut_s9srpcclient/ut_s9srpcclient.h
+++ b/tests/ut_s9srpcclient/ut_s9srpcclient.h
@@ -65,6 +65,7 @@ class UtS9sRpcClient : public S9sUnitTest
         bool testCreateCluster04();
         bool testCreateCluster05();
         bool testCreateCluster06();
+        bool testRegisterClickHouse();
 
         bool testGetAllClusterInfo();
         bool testGetCluster();


### PR DESCRIPTION
Adds ClickHouse to `s9s cluster --register --cluster-type=clickhouse`, so an
existing single-node or replicated ClickHouse can be imported from one endpoint:

    s9s cluster --register --cluster-type=clickhouse \
        --nodes="clickhouse://<host>:9440" --cluster-name=...
