### PR TITLE
CLUS-6881 Forward PgBouncer admin user/password in add-node request

### DIFF
--- a/libs9s/s9srpcclient.cpp
+++ b/libs9s/s9srpcclient.cpp
@@ -5949,7 +5949,24 @@ S9sRpcClient::addPgBouncer(
     
     // The job_data describing the cluster.
     jobData["action"]   = "setup";
-    jobData["nodes"]    = nodesField(nodes);        
+    jobData["nodes"]    = nodesField(nodes);
+
+    // Forward the admin account. cmon reads /job_data/admin_username and
+    // /job_data/admin_password (the same keys the web UI sends). Without
+    // this the --admin-user/--admin-password options are dropped and the
+    // admin silently falls back to 'pgbadmin' (CLUS-6881/CLUS-6892: the
+    // name may legitimately contain '-').
+    {
+        S9sOptions *options         = S9sOptions::instance();
+        S9sString   adminUser       = options->getString("admin_user", "");
+        S9sString   adminPassword   = options->getString("admin_password", "");
+
+        if (!adminUser.empty())
+            jobData["admin_username"] = adminUser;
+
+        if (!adminPassword.empty())
+            jobData["admin_password"] = adminPassword;
+    }
 
     // The jobspec describing the command.
     jobSpec["command"]    = "pgbouncer";


### PR DESCRIPTION
## What & why

The PgBouncer add-node path (`S9sRpcClient::addPgBouncer`) built the job request with only `action` + `nodes`, silently dropping the `--admin-user` / `--admin-password` options. cmon then fell back to the default `pgbadmin`, so a requested admin name was ignored — and a name containing `-` never even reached the controller.

This is the s9s-tools half of the CLUS-6892 work (allow `-` in PostgreSQL usernames). It pairs with the cmon-side identifier-quoting fixes (clustercontrol-enterprise PR #3216).

## Change

`addPgBouncer()` now sends `admin_username` / `admin_password` in `job_data` — the same keys the web UI sends and that cmon's `setupJobToPgBouncerHosts` reads — mirroring the existing ProxySQL handling.

## Verification (live)

- Before: `s9s cluster --add-node --nodes='pgbouncer://…' --admin-user='my-pgb-admin'` → job_data had no admin key → cmon created `pgbadmin`.
- After (this build): the same command sends `admin_username='my-pgb-admin'`; the PgBouncer deploy completes with the role `my-pgb-admin` created and the node up (with the cmon-side quoting fixes in place).

Addresses Martin's QA scenario #2 on CLUS-6881 (PgBouncer admin with `-`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)