### PR TITLE
CLUS-7713: s9s: add --remove-certificates for cluster --drop

### DIFF
--- a/doc/s9s-cluster.1
+++ b/doc/s9s-cluster.1
@@ -354,13 +354,29 @@ s9s cluster \\
 Removes the cluster from the Cmon controller. The cluster remains operational,
 but the controller will no longer manage or monitor it.
 
+Without \fB\-\-force\fR the first failing removal step (stopping the cluster
+management, deleting the backups) fails the job and the cleanup stops there.
+The removal can be repeated any time \(em also for a cluster whose metadata
+was only partially removed by an earlier, interrupted attempt \(em until all
+metadata is gone.
+
+With \fB\-\-force\fR a failing step is reported as a warning in the job log
+and the cleanup continues. If the cluster management cannot be stopped, the
+cluster configuration file is archived right away \(em so the cluster cannot
+come back after a controller restart \(em and the removal is re\-attempted
+automatically a few times by the job retry mechanism.
+
+With \fB\-\-remove\-certificates\fR the certificate files the controller
+generated for the cluster are deleted; by default they are archived so they
+can still be used to access the cluster outside of ClusterControl.
+
 .B EXAMPLE
 .nf
 s9s cluster \\
     --drop \\
     --cluster-id=1 \\
     --remove-backups=true \\
-    --wait 
+    --wait
 .fi
 
 .TP 

--- a/doc/s9s-cluster.1
+++ b/doc/s9s-cluster.1
@@ -367,8 +367,9 @@ come back after a controller restart \(em and the removal is re\-attempted
 automatically a few times by the job retry mechanism.
 
 With \fB\-\-remove\-certificates\fR the certificate files the controller
-generated for the cluster are deleted; by default they are archived so they
-can still be used to access the cluster outside of ClusterControl.
+generated for the cluster are deleted; by default they are kept untouched so
+they can still be used to access the cluster outside of ClusterControl and a
+later re\-import of the cluster keeps working with them.
 
 .B EXAMPLE
 .nf

--- a/libs9s/s9soptions.cpp
+++ b/libs9s/s9soptions.cpp
@@ -211,6 +211,7 @@ enum S9sOptionType
     OptionUninstall,
     OptionUnregisterOnly,
     OptionRemoveBackups,
+    OptionRemoveCertificates,
     OptionUuid,
     OptionDateFormat,
     OptionFullUuid,
@@ -2597,6 +2598,22 @@ bool
 S9sOptions::hasRemoveBackupsOption() const
 {
     return m_options.contains("remove_backups");
+}
+
+/**
+ * \returns true if the --remove-certificates command line option was
+ *   provided.
+ */
+bool
+S9sOptions::hasRemoveCertificatesOption() const
+{
+    return m_options.contains("remove_certificates");
+}
+
+bool
+S9sOptions::removeCertificates() const
+{
+    return getBool("remove_certificates");
 }
 
 bool
@@ -15342,6 +15359,7 @@ S9sOptions::readOptionsCluster(
         { "uninstall",           no_argument,       0,  OptionUninstall     },
         { "unregister-only",     no_argument,       0,  OptionUnregisterOnly },
         { "remove-backups",      required_argument, 0,  OptionRemoveBackups },
+        { "remove-certificates", no_argument,       0,  OptionRemoveCertificates },
 
         // Options for mssql
         { "license",     required_argument, 0, OptionLicense     },
@@ -16415,6 +16433,11 @@ S9sOptions::readOptionsCluster(
             case OptionRemoveBackups:
                 // --remove-backups
                 m_options["remove_backups"] = optarg;
+                break;
+
+            case OptionRemoveCertificates:
+                // --remove-certificates
+                m_options["remove_certificates"] = true;
                 break;
 
 

--- a/libs9s/s9soptions.h
+++ b/libs9s/s9soptions.h
@@ -252,6 +252,8 @@ class S9sOptions
 
         bool removeBackups() const;
         bool hasRemoveBackupsOption() const;
+        bool removeCertificates() const;
+        bool hasRemoveCertificatesOption() const;
 
         bool forceOption() const;
         bool hasForceOption() const;

--- a/libs9s/s9srpcclient.cpp
+++ b/libs9s/s9srpcclient.cpp
@@ -8125,6 +8125,9 @@ S9sRpcClient::dropCluster()
     if (options->hasRemoveBackupsOption())
         jobData["remove_backups"]  = options->removeBackups() ? "true" : "false";
 
+    if (options->hasRemoveCertificatesOption())
+        jobData["remove_certificates"] = options->removeCertificates();
+
     // Well, this is not going to work.
     if (options->hasClusterNameOption())
         jobData["cluster_name"] = options->clusterName();


### PR DESCRIPTION
> ***by AI agent on behalf of Peter Csaszar***

Adds the --remove-certificates option to s9s cluster --drop: when given, the controller deletes the certificate files it generated for the cluster; by default they are archived (moved aside) so the customer can keep using them outside of ClusterControl. Pairs with the cmon-side remove_certificates job option.

Also rewrites the s9s-cluster.1 --drop entry to state the exact drop semantics: without --force the first failing step fails the job and the removal stays repeatable until all metadata is gone; with --force failing steps become warnings, the cleanup continues, and a stop-timeout leads to config archival plus automatic re-attempts.

## Jira
https://severalnines.atlassian.net/browse/CLUS-7713

## TestRunner2
https://testrunner2.severalnines.com/?compare&results&--branch=CLUS-7713-force-drop-cluster&--ref-branch=2.4.0_release

> ***by AI agent on behalf of Peter Csaszar***