### PR TITLE
CLUS-8174: Document or expose  in Usage:

### DIFF
--- a/libs9s/s9srpcclient.cpp
+++ b/libs9s/s9srpcclient.cpp
@@ -13698,7 +13698,7 @@ S9sRpcClient::registerRedisOrValkeyShardedCluster(
     else
     {
         S9sString clusterName = isValkeyCluster ? "valkey" : "redis";
-        PRINT_ERROR("%s sharded cluster requires '--%s-sharded-port' option",
+        PRINT_ERROR("%s sharded cluster requires '--%s-port' option",
                     STR(clusterName),
                     STR(clusterName));
         return false;


### PR DESCRIPTION
Fixed showing wrong parameter name in the error message when registering redis sharded cluster

- https://severalnines.atlassian.net/browse/CLUS-8174
- https://severalnines.atlassian.net/browse/CLUS-8165
- https://severalnines.atlassian.net/browse/CLUS-8176
