### PR TITLE
CLUS-7713: s9s man: controller-side certificate store wording

### DIFF
--- a/doc/s9s-cluster.1
+++ b/doc/s9s-cluster.1
@@ -366,10 +366,14 @@ cluster configuration file is archived right away \(em so the cluster cannot
 come back after a controller restart \(em and the removal is re\-attempted
 automatically a few times by the job retry mechanism.
 
-With \fB\-\-remove\-certificates\fR the certificate files the controller
-generated for the cluster are deleted; by default they are kept untouched so
-they can still be used to access the cluster outside of ClusterControl and a
-later re\-import of the cluster keeps working with them.
+With \fB\-\-remove\-certificates\fR the controller\-side certificate store
+of the cluster \(em the certificate files the controller generated for it
+and their database records \(em is deleted; every removed file is listed in
+the job log. By default the store is kept untouched so the certificates can
+still be used to access the cluster outside of ClusterControl and a later
+re\-import of the cluster keeps working with them. The certificate files
+that were deployed onto the database nodes are never touched: the database
+keeps running with them.
 
 .B EXAMPLE
 .nf


### PR DESCRIPTION
> ***by AI agent on behalf of Peter Csaszar***

Clarifies the s9s cluster --drop man entry: --remove-certificates deletes the controller-side certificate store (files + database records, each removed file listed in the job log), while the certificate files deployed onto the database nodes are never touched. Follow-up to #213.

## Jira
https://severalnines.atlassian.net/browse/CLUS-7713

🤖 Generated with [Claude Code](https://claude.com/claude-code)