### PR TITLE
CLUS-7060: pgBackRest S3 backup repository (CLI)

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -15,6 +15,10 @@ s9s-tools (1.9.2026011315-release1) UNRELEASED; urgency=medium
     data collection instead of using cached information.
   * CLUS-6878: Added --refresh option to replication command to bypass
     cluster info cache and get live data.
+  * CLUS-7060: Added --credential-id and --s3-bucket options to the cluster
+    command so PgBackRest can use an S3 (object store) backup repository
+    referenced by a registered cloud credential, on add-node, reconfigure
+    and reinstall.
 
  -- Peter Csaszar <peter@severalnines.com>  Tue, 13 Jan 2026 15:21:55 +0100
 

--- a/doc/s9s-cluster.1
+++ b/doc/s9s-cluster.1
@@ -1659,6 +1659,23 @@ The mysql username of the maxscale balancer.
 .BI --maxscale-mysql-password= PASSWORD
 The password of the mysql user of the maxscale balancer.
 
+.TP
+.BI --credential-id= ID
+When adding, reconfiguring or reinstalling PgBackRest, this selects a previously
+registered cloud credential (see
+.BR s9s-cloud-credentials (1))
+to use an S3 (object store) backup repository instead of a local directory. The
+credential provides the S3 endpoint, region, access key, secret and TLS
+settings. On reconfigure or reinstall it may be omitted to keep the current
+repository.
+
+.TP
+.BI --s3-bucket= NAME
+The S3 bucket that holds the PgBackRest backup repository, used together with
+.BR --credential-id .
+Required when first configuring an S3 repository; on reconfigure or reinstall it
+may be omitted to reuse the bucket stored at install time.
+
 
 \"
 \"

--- a/libs9s/s9soptions.cpp
+++ b/libs9s/s9soptions.cpp
@@ -4085,31 +4085,21 @@ S9sOptions::comment() const
 }
 
 /**
- * \returns The argument for the --s3-use-ssl option
- *
- * CLUS-7060: the cloud-credentials option parser stores this flag under the
- * "s3_use_ssl" key (see readOptionsCloudCredentials), so read that key here —
- * otherwise --s3-use-ssl would never reach the stored credential.
+ * \returns The argument for the --use-ssl option
  */
 bool
 S9sOptions::hasUseSsl() const
 {
-    return m_options.contains("s3_use_ssl") || m_options.contains("use_ssl");
+    return m_options.contains("use_ssl");
 }
 
 /**
- * \returns The argument for the --s3-insecure-ssl option
- *
- * CLUS-7060: the cloud-credentials option parser stores this flag under the
- * "s3_insecure_ssl" key, so read that key here — otherwise --s3-insecure-ssl
- * would never reach the stored credential and TLS verification could not be
- * turned off.
+ * \returns The argument for the --insecure-ssl option
  */
 bool
 S9sOptions::hasInsecureSsl() const
 {
-    return m_options.contains("s3_insecure_ssl") ||
-           m_options.contains("insecure_ssl");
+    return m_options.contains("insecure_ssl");
 }
 
 /**
@@ -15315,11 +15305,10 @@ S9sOptions::readOptionsCluster(
         { "cloud",            required_argument, 0, OptionCloud           },
         { "containers",       required_argument, 0, OptionContainers      },
         { "credential-id",    required_argument, 0, OptionCredentialId    },
-        // CLUS-7060: S3 backup repository options for PgBackRest add-node.
-        { "cloud-provider",   required_argument, 0, OptionCloudProvider   },
-        { "cloud-only",       no_argument,       0, OptionOnlyCloud       },
+        // CLUS-7060: the S3 backup repository for a PgBackRest add-node is
+        // referenced by a registered cloud credential (--credential-id, already
+        // above). The only value the credential does not carry is the bucket.
         { "s3-bucket",        required_argument, 0, OptionS3Bucket        },
-        { "s3-region",        required_argument, 0, OptionS3Region        },
         { "firewalls",        required_argument, 0, OptionFirewalls       },
         { "generate-key",     no_argument,       0, 'g'                   },
         { "image",            required_argument, 0, OptionImage           },
@@ -16179,24 +16168,9 @@ S9sOptions::readOptionsCluster(
                 m_options["credential_id"] = optarg;
                 break;
 
-            case OptionCloudProvider:
-                // --cloud-provider=NAME  (CLUS-7060: PgBackRest S3 repo)
-                m_options["cloud_provider"] = optarg;
-                break;
-
-            case OptionOnlyCloud:
-                // --cloud-only  (CLUS-7060: PgBackRest S3 repo)
-                m_options["cloud_only"] = true;
-                break;
-
             case OptionS3Bucket:
-                // --s3-bucket=NAME  (CLUS-7060: PgBackRest S3 repo)
+                // --s3-bucket=NAME  (CLUS-7060: PgBackRest S3 repo bucket)
                 m_options["s3_bucket"] = optarg;
-                break;
-
-            case OptionS3Region:
-                // --s3-region=STRING  (CLUS-7060: PgBackRest S3 repo)
-                m_options["s3_region"] = optarg;
                 break;
 
             case OptionFirewalls:

--- a/libs9s/s9soptions.cpp
+++ b/libs9s/s9soptions.cpp
@@ -15305,9 +15305,6 @@ S9sOptions::readOptionsCluster(
         { "cloud",            required_argument, 0, OptionCloud           },
         { "containers",       required_argument, 0, OptionContainers      },
         { "credential-id",    required_argument, 0, OptionCredentialId    },
-        // CLUS-7060: the S3 backup repository for a PgBackRest add-node is
-        // referenced by a registered cloud credential (--credential-id, already
-        // above). The only value the credential does not carry is the bucket.
         { "s3-bucket",        required_argument, 0, OptionS3Bucket        },
         { "firewalls",        required_argument, 0, OptionFirewalls       },
         { "generate-key",     no_argument,       0, 'g'                   },
@@ -16169,7 +16166,7 @@ S9sOptions::readOptionsCluster(
                 break;
 
             case OptionS3Bucket:
-                // --s3-bucket=NAME  (CLUS-7060: PgBackRest S3 repo bucket)
+                // --s3-bucket=NAME
                 m_options["s3_bucket"] = optarg;
                 break;
 

--- a/libs9s/s9soptions.cpp
+++ b/libs9s/s9soptions.cpp
@@ -4085,21 +4085,31 @@ S9sOptions::comment() const
 }
 
 /**
- * \returns The argument for the --use-ssl option
+ * \returns The argument for the --s3-use-ssl option
+ *
+ * CLUS-7060: the cloud-credentials option parser stores this flag under the
+ * "s3_use_ssl" key (see readOptionsCloudCredentials), so read that key here —
+ * otherwise --s3-use-ssl would never reach the stored credential.
  */
 bool
 S9sOptions::hasUseSsl() const
 {
-    return m_options.contains("use_ssl");
+    return m_options.contains("s3_use_ssl") || m_options.contains("use_ssl");
 }
 
 /**
- * \returns The argument for the --insecure-ssl option
+ * \returns The argument for the --s3-insecure-ssl option
+ *
+ * CLUS-7060: the cloud-credentials option parser stores this flag under the
+ * "s3_insecure_ssl" key, so read that key here — otherwise --s3-insecure-ssl
+ * would never reach the stored credential and TLS verification could not be
+ * turned off.
  */
 bool
 S9sOptions::hasInsecureSsl() const
 {
-    return m_options.contains("insecure_ssl");
+    return m_options.contains("s3_insecure_ssl") ||
+           m_options.contains("insecure_ssl");
 }
 
 /**
@@ -15305,8 +15315,13 @@ S9sOptions::readOptionsCluster(
         { "cloud",            required_argument, 0, OptionCloud           },
         { "containers",       required_argument, 0, OptionContainers      },
         { "credential-id",    required_argument, 0, OptionCredentialId    },
+        // CLUS-7060: S3 backup repository options for PgBackRest add-node.
+        { "cloud-provider",   required_argument, 0, OptionCloudProvider   },
+        { "cloud-only",       no_argument,       0, OptionOnlyCloud       },
+        { "s3-bucket",        required_argument, 0, OptionS3Bucket        },
+        { "s3-region",        required_argument, 0, OptionS3Region        },
         { "firewalls",        required_argument, 0, OptionFirewalls       },
-        { "generate-key",     no_argument,       0, 'g'                   }, 
+        { "generate-key",     no_argument,       0, 'g'                   },
         { "image",            required_argument, 0, OptionImage           },
         { "image-os-user",    required_argument, 0, OptionImageOsUser     },
            { "os-sudo-password", required_argument, 0, OptionOsSudoPassword  },
@@ -16158,10 +16173,30 @@ S9sOptions::readOptionsCluster(
                 // --containers=LIST
                 setContainers(optarg);
                 break;
-            
+
             case OptionCredentialId:
                 // --credential-id=ID
                 m_options["credential_id"] = optarg;
+                break;
+
+            case OptionCloudProvider:
+                // --cloud-provider=NAME  (CLUS-7060: PgBackRest S3 repo)
+                m_options["cloud_provider"] = optarg;
+                break;
+
+            case OptionOnlyCloud:
+                // --cloud-only  (CLUS-7060: PgBackRest S3 repo)
+                m_options["cloud_only"] = true;
+                break;
+
+            case OptionS3Bucket:
+                // --s3-bucket=NAME  (CLUS-7060: PgBackRest S3 repo)
+                m_options["s3_bucket"] = optarg;
+                break;
+
+            case OptionS3Region:
+                // --s3-region=STRING  (CLUS-7060: PgBackRest S3 repo)
+                m_options["s3_region"] = optarg;
                 break;
 
             case OptionFirewalls:

--- a/libs9s/s9srpcclient.cpp
+++ b/libs9s/s9srpcclient.cpp
@@ -5957,12 +5957,35 @@ S9sRpcClient::addPgBackRest(
     
     // The job_data describing the cluster.
     jobData["action"]   = "setup";
-    jobData["nodes"]    = nodesField(nodes);        
+    jobData["nodes"]    = nodesField(nodes);
+
+    // CLUS-7060: forward the S3 backup-repository options so the controller
+    // configures pgBackRest to use an S3 (object store) repository instead of
+    // a local posix path. The referenced credential (credential-id) carries
+    // the S3 endpoint, access key and secret.
+    {
+        S9sOptions   *options = S9sOptions::instance();
+        S9sString     cloudProvider = options->cloudProvider();
+
+        if (!cloudProvider.empty())
+        {
+            jobData["cloud_provider"] = cloudProvider;
+
+            if (options->cloudOnly())
+                jobData["cloud_only"] = true;
+            if (!options->s3bucket().empty())
+                jobData["s3_bucket"] = options->s3bucket();
+            if (!options->s3region().empty())
+                jobData["s3_region"] = options->s3region();
+            if (options->hasCredentialIdOption())
+                jobData["credential_id"] = options->credentialId();
+        }
+    }
 
     // The jobspec describing the command.
     jobSpec["command"]    = "pgbackrest";
     jobSpec["job_data"]   = jobData;
-    
+
     // The job instance describing how the job will be executed.
     job["title"]          = "Add PgBackRest to Cluster";
     job["job_spec"]       = jobSpec;

--- a/libs9s/s9srpcclient.cpp
+++ b/libs9s/s9srpcclient.cpp
@@ -5926,6 +5926,28 @@ S9sRpcClient::addKeepalived(
 }
 
 /**
+ * CLUS-7060: An S3 (object store) backup repository is referenced by a
+ * registered cloud credential id; only the bucket is passed alongside (the
+ * credential has no bucket). Shared by the pgbackrest setup, reconfigure and
+ * reinstall job builders. When no credential id is given nothing is added, so
+ * reconfigure/reinstall keep the repository configuration stored at install
+ * time.
+ */
+void
+S9sRpcClient::addPgBackRestS3RepoToJobData(
+        S9sVariantMap &jobData)
+{
+    S9sOptions *options = S9sOptions::instance();
+
+    if (options->hasCredentialIdOption())
+    {
+        jobData["credential_id"] = options->credentialId();
+        if (!options->s3bucket().empty())
+            jobData["s3_bucket"] = options->s3bucket();
+    }
+}
+
+/**
  * \param clusterId The ID of the cluster.
  * \returns true if the request sent and a return is received (even if the reply
  *   is an error message).
@@ -5959,18 +5981,7 @@ S9sRpcClient::addPgBackRest(
     jobData["action"]   = "setup";
     jobData["nodes"]    = nodesField(nodes);
 
-    // An S3 backup repository is referenced by a registered cloud credential
-    // id; only the bucket is passed alongside (the credential has no bucket).
-    {
-        S9sOptions *options = S9sOptions::instance();
-
-        if (options->hasCredentialIdOption())
-        {
-            jobData["credential_id"] = options->credentialId();
-            if (!options->s3bucket().empty())
-                jobData["s3_bucket"] = options->s3bucket();
-        }
-    }
+    addPgBackRestS3RepoToJobData(jobData);
 
     // The jobspec describing the command.
     jobSpec["command"]    = "pgbackrest";
@@ -6759,18 +6770,7 @@ S9sRpcClient::reconfigurePgBackRest(
     jobData["action"]   = "reconfigure";
     jobData["nodes"]    = nodesField(nodes);
 
-    // (Re)point the repository to an S3 bucket by cloud credential id; when no
-    // credential id is given the current repository configuration is kept.
-    {
-        S9sOptions *options = S9sOptions::instance();
-
-        if (options->hasCredentialIdOption())
-        {
-            jobData["credential_id"] = options->credentialId();
-            if (!options->s3bucket().empty())
-                jobData["s3_bucket"] = options->s3bucket();
-        }
-    }
+    addPgBackRestS3RepoToJobData(jobData);
 
     // The jobspec describing the command.
     jobSpec["command"]    = "pgbackrest";
@@ -6925,18 +6925,7 @@ S9sRpcClient::reinstallPgBackRest(
     jobData["action"]   = "reinstall";
     jobData["nodes"]    = nodesField(nodes);
 
-    // (Re)point the repository to an S3 bucket by cloud credential id; when no
-    // credential id is given the current repository configuration is kept.
-    {
-        S9sOptions *options = S9sOptions::instance();
-
-        if (options->hasCredentialIdOption())
-        {
-            jobData["credential_id"] = options->credentialId();
-            if (!options->s3bucket().empty())
-                jobData["s3_bucket"] = options->s3bucket();
-        }
-    }
+    addPgBackRestS3RepoToJobData(jobData);
 
     // The jobspec describing the command.
     jobSpec["command"]    = "pgbackrest";

--- a/libs9s/s9srpcclient.cpp
+++ b/libs9s/s9srpcclient.cpp
@@ -5959,12 +5959,8 @@ S9sRpcClient::addPgBackRest(
     jobData["action"]   = "setup";
     jobData["nodes"]    = nodesField(nodes);
 
-    // CLUS-7060: an S3 (object store) backup repository is requested by
-    // referencing a registered cloud credential by id. The controller fetches
-    // the credential (endpoint, region, access key/secret, ssl) from its own
-    // credential store; the only value not held by the credential is the
-    // bucket, so that is passed alongside. No S3-specific credential options
-    // are re-typed here — this mirrors the snapshot-repository convention.
+    // An S3 backup repository is referenced by a registered cloud credential
+    // id; only the bucket is passed alongside (the credential has no bucket).
     {
         S9sOptions *options = S9sOptions::instance();
 
@@ -6763,6 +6759,19 @@ S9sRpcClient::reconfigurePgBackRest(
     jobData["action"]   = "reconfigure";
     jobData["nodes"]    = nodesField(nodes);
 
+    // (Re)point the repository to an S3 bucket by cloud credential id; when no
+    // credential id is given the current repository configuration is kept.
+    {
+        S9sOptions *options = S9sOptions::instance();
+
+        if (options->hasCredentialIdOption())
+        {
+            jobData["credential_id"] = options->credentialId();
+            if (!options->s3bucket().empty())
+                jobData["s3_bucket"] = options->s3bucket();
+        }
+    }
+
     // The jobspec describing the command.
     jobSpec["command"]    = "pgbackrest";
     jobSpec["job_data"]   = jobData;
@@ -6915,6 +6924,19 @@ S9sRpcClient::reinstallPgBackRest(
     // The job_data describing the cluster.
     jobData["action"]   = "reinstall";
     jobData["nodes"]    = nodesField(nodes);
+
+    // (Re)point the repository to an S3 bucket by cloud credential id; when no
+    // credential id is given the current repository configuration is kept.
+    {
+        S9sOptions *options = S9sOptions::instance();
+
+        if (options->hasCredentialIdOption())
+        {
+            jobData["credential_id"] = options->credentialId();
+            if (!options->s3bucket().empty())
+                jobData["s3_bucket"] = options->s3bucket();
+        }
+    }
 
     // The jobspec describing the command.
     jobSpec["command"]    = "pgbackrest";

--- a/libs9s/s9srpcclient.cpp
+++ b/libs9s/s9srpcclient.cpp
@@ -5959,26 +5959,20 @@ S9sRpcClient::addPgBackRest(
     jobData["action"]   = "setup";
     jobData["nodes"]    = nodesField(nodes);
 
-    // CLUS-7060: forward the S3 backup-repository options so the controller
-    // configures pgBackRest to use an S3 (object store) repository instead of
-    // a local posix path. The referenced credential (credential-id) carries
-    // the S3 endpoint, access key and secret.
+    // CLUS-7060: an S3 (object store) backup repository is requested by
+    // referencing a registered cloud credential by id. The controller fetches
+    // the credential (endpoint, region, access key/secret, ssl) from its own
+    // credential store; the only value not held by the credential is the
+    // bucket, so that is passed alongside. No S3-specific credential options
+    // are re-typed here — this mirrors the snapshot-repository convention.
     {
-        S9sOptions   *options = S9sOptions::instance();
-        S9sString     cloudProvider = options->cloudProvider();
+        S9sOptions *options = S9sOptions::instance();
 
-        if (!cloudProvider.empty())
+        if (options->hasCredentialIdOption())
         {
-            jobData["cloud_provider"] = cloudProvider;
-
-            if (options->cloudOnly())
-                jobData["cloud_only"] = true;
+            jobData["credential_id"] = options->credentialId();
             if (!options->s3bucket().empty())
                 jobData["s3_bucket"] = options->s3bucket();
-            if (!options->s3region().empty())
-                jobData["s3_region"] = options->s3region();
-            if (options->hasCredentialIdOption())
-                jobData["credential_id"] = options->credentialId();
         }
     }
 

--- a/libs9s/s9srpcclient.h
+++ b/libs9s/s9srpcclient.h
@@ -708,6 +708,11 @@ class S9sRpcClient
         bool addPgBackRest(
                 const S9sVariantList &hosts);
 
+        // CLUS-7060: add the S3 backup-repository reference (cloud credential id
+        // + bucket) to a pgbackrest setup/reconfigure/reinstall job_data.
+        static void addPgBackRestS3RepoToJobData(
+                S9sVariantMap &jobData);
+
         bool addPBMAgent(
                 const S9sVariantList &hosts);
 


### PR DESCRIPTION
> ***by AI agent on behalf of Peter Csaszar***

Adds S3 (object store) backup-repository support to the pgBackRest cluster commands.

## Concept
An S3 repository is referenced by a **registered cloud credential id** — the same convention as snapshot repositories. All S3 connection details (provider, endpoint, region, access key/secret, TLS) come from the stored credential; nothing is re-typed on the command. The only value the credential cannot carry is the **bucket**, so that is the single extra parameter.

## Changes (`libs9s`)
- `cluster` mode: reuse the existing `--credential-id`, add `--s3-bucket`. No `--cloud-provider`/`--s3-region`/`--cloud-only` (all derivable from the credential).
- `addPgBackRest` forwards `credential_id` + `s3_bucket` into the pgbackrest `setup` job.
- `reconfigurePgBackRest` / `reinstallPgBackRest` forward the same, so an S3 repository is **preserved** (omit → keep stored config) or **re-pointed** (credential-id [+ bucket]).

## Usage
```
s9s cluster --add-node --cluster-id=N --nodes="pgbackrest://*" \
    --credential-id=<id> --s3-bucket=<bucket>
```

## Notes
- Backend (`clustercontrol-enterprise`) and test (`s9s-cmon-test`) changes are in companion PRs.
- TestRunner installs `s9s` from the `s9s-tools-testing` package repo (not the branch), so the companion ft_test can only go green on TestRunner **after this is merged and published**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

> ***by AI agent on behalf of Peter Csaszar***