### PR TITLE
CLUS-7060: make cloud-credential use_ssl honor --s3-use-ssl

### DIFF
--- a/libs9s/s9soptions.cpp
+++ b/libs9s/s9soptions.cpp
@@ -4113,12 +4113,15 @@ S9sOptions::comment() const
 }
 
 /**
- * \returns The argument for the --use-ssl option
+ * \returns true if the --s3-use-ssl option was provided.
  */
 bool
 S9sOptions::hasUseSsl() const
 {
-    return m_options.contains("use_ssl");
+    // The only option that toggles this is --s3-use-ssl, which stores the flag
+    // under "s3_use_ssl"; reading "use_ssl" here left it always false (so an
+    // https endpoint was registered with use_ssl=false).
+    return m_options.contains("s3_use_ssl");
 }
 
 /**


### PR DESCRIPTION
> ***by AI agent on behalf of Peter Csaszar***

`--s3-use-ssl` stored the flag under key `s3_use_ssl`, but `S9sOptions::hasUseSsl()` read `use_ssl` — a key nothing sets, so `cloud-credentials --create --s3-use-ssl` always sent `use_ssl:false` even for an `https://` S3 endpoint. Pre-existing since CLUS-4776 (fa555752). cmon drives TLS from the endpoint scheme so backups still worked — only stored metadata was wrong. Fix: read the `s3_use_ssl` key. Verified via `--print-request`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VBqy4ofC8coFay87eGCN9M

> ***by AI agent on behalf of Peter Csaszar***