### PR TITLE
CLUS-8389: add 'pool-controllers --add-db' CLI support for CmdAddCmonDbInstance

### DIFF
--- a/libs9s/s9sbusinesslogic.cpp
+++ b/libs9s/s9sbusinesslogic.cpp
@@ -1511,6 +1511,18 @@ S9sBusinessLogic::execute()
             S9sRpcReply reply = client.reply();
             maybeJobRegistered(client, clusterId, success);
         }
+        else if (options->isImportDb())
+        {
+            success = client.importCmonDbInstance(options);
+            S9sRpcReply reply = client.reply();
+            maybeJobRegistered(client, clusterId, success);
+        }
+        else if (options->isDeleteDb())
+        {
+            success = client.deleteCmonDbInstance(options);
+            S9sRpcReply reply = client.reply();
+            maybeJobRegistered(client, clusterId, success);
+        }
         else if (options->isStartController())
         {
             client.startController(options);

--- a/libs9s/s9sbusinesslogic.cpp
+++ b/libs9s/s9sbusinesslogic.cpp
@@ -1475,6 +1475,11 @@ S9sBusinessLogic::execute()
             S9sRpcReply reply = client.reply();
             reply.printPoolControllers();
         }
+        else if (options->isListDb()) {
+            client.listDbClusterNodes(options);
+            S9sRpcReply reply = client.reply();
+            reply.printCmonDbClusterNodes();
+        }
         else if (options->isAssignedController()) {
             client.assignedController(options);
             S9sRpcReply reply = client.reply();

--- a/libs9s/s9sbusinesslogic.cpp
+++ b/libs9s/s9sbusinesslogic.cpp
@@ -1505,6 +1505,12 @@ S9sBusinessLogic::execute()
             S9sRpcReply reply = client.reply();
             maybeJobRegistered(client, clusterId, success);
         }
+        else if (options->isAddDb())
+        {
+            success = client.addNewCmonDbInstance(options);
+            S9sRpcReply reply = client.reply();
+            maybeJobRegistered(client, clusterId, success);
+        }
         else if (options->isStartController())
         {
             client.startController(options);

--- a/libs9s/s9soptions.cpp
+++ b/libs9s/s9soptions.cpp
@@ -539,6 +539,8 @@ enum S9sOptionType
 
     OptionAddController,
     OptionAddDb,
+    OptionImportDb,
+    OptionDeleteDb,
     OptionControllersList,
     OptionPrintDeploymentInfo,
     OptionAssignedController,
@@ -5644,6 +5646,28 @@ S9sOptions::isAddDb() const
 }
 
 /**
+ * \returns true if the "import-db" function is requested by providing the
+ * --import-db command line option (imports an existing, standalone cmon DB
+ * instance into the pool via the importCmonDbInstance job).
+ */
+bool
+S9sOptions::isImportDb() const
+{
+    return getBool("import_db");
+}
+
+/**
+ * \returns true if the "delete-db" function is requested by providing the
+ * --delete-db command line option (removes a cmon DB instance from the
+ * pool's cmon DB HA InnoDB Cluster via the deleteCmonDbInstance job).
+ */
+bool
+S9sOptions::isDeleteDb() const
+{
+    return getBool("delete_db");
+}
+
+/**
  * \returns true if the --start command line option was provided for controllers
  */
 bool
@@ -9044,6 +9068,10 @@ S9sOptions::printHelpControllers()
 "  --add-controller           To create a new controller instance on specified host.\n"
 "  --add-db                   To join a host into the pool's cmon DB HA InnoDB Cluster\n"
 "                             as a SECONDARY (requires --nodes with exactly one node).\n"
+"  --import-db                To import an existing, standalone cmon DB instance into\n"
+"                             the pool (requires --nodes with exactly one node).\n"
+"  --delete-db                To remove a cmon DB instance from the pool's cmon DB HA\n"
+"                             InnoDB Cluster (requires --nodes with exactly one node).\n"
 "  --assignment               To retrieve the controller assigned to specific cluster (requires --cluster-id).\n"
 "  --start                    To start a controller (requires --controller-id).\n"
 "  --stop                     To stop a controller (requires --controller-id).\n"
@@ -9066,7 +9094,9 @@ S9sOptions::printHelpControllers()
 "                             go inactive); the pool thread abandons the affected clusters on\n"
 "                             its next cycle. With --add-db: proceed even if an existing,\n"
 "                             unrelated MySQL installation is detected on the target host\n"
-"                             (its data will be overwritten by the join).\n"
+"                             (its data will be overwritten by the join). With --delete-db:\n"
+"                             remove the instance from the cluster's metadata even if it\n"
+"                             cannot be reached (mirrors mysqlsh's remove_instance(force)).\n"
 "\n"
 "Job related options:\n"
 "  --log                      Wait and monitor job messages.\n"
@@ -19964,6 +19994,8 @@ S9sOptions::readOptionsControllers(
                     {"print-deployment-info", no_argument, 0,  OptionPrintDeploymentInfo},
                     {"add-controller",   no_argument, 0,       OptionAddController},
                     {"add-db",           no_argument, 0,       OptionAddDb},
+                    {"import-db",        no_argument, 0,       OptionImportDb},
+                    {"delete-db",        no_argument, 0,       OptionDeleteDb},
                     {"assignment",       no_argument, 0,       OptionAssignedController},
                     {"set-pool-mode",   no_argument,  0,       OptionSetPoolMode},
                     {"unset-pool-mode", no_argument,  0,       OptionUnsetPoolMode},
@@ -20196,6 +20228,16 @@ S9sOptions::readOptionsControllers(
                 m_options["add_db"] = true;
                 break;
 
+            case OptionImportDb:
+                // --import-db
+                m_options["import_db"] = true;
+                break;
+
+            case OptionDeleteDb:
+                // --delete-db
+                m_options["delete_db"] = true;
+                break;
+
             case OptionStartController:
                 // --start
                 m_options["start_controller"] = true;
@@ -20338,6 +20380,12 @@ S9sOptions::checkOptionsControllers()
         countOptions++;
 
     if (isAddDb())
+        countOptions++;
+
+    if (isImportDb())
+        countOptions++;
+
+    if (isDeleteDb())
         countOptions++;
 
     if (isStartController())

--- a/libs9s/s9soptions.cpp
+++ b/libs9s/s9soptions.cpp
@@ -538,6 +538,7 @@ enum S9sOptionType
     OptionWatchlistProperties,
 
     OptionAddController,
+    OptionAddDb,
     OptionControllersList,
     OptionPrintDeploymentInfo,
     OptionAssignedController,
@@ -5632,6 +5633,17 @@ S9sOptions::isAddController() const
 }
 
 /**
+ * \returns true if the "add-db" function is requested by providing the
+ * --add-db command line option (joins the given node into the pool's
+ * cmon DB HA InnoDB Cluster as a SECONDARY, via the addCmonDbInstance job).
+ */
+bool
+S9sOptions::isAddDb() const
+{
+    return getBool("add_db");
+}
+
+/**
  * \returns true if the --start command line option was provided for controllers
  */
 bool
@@ -9030,6 +9042,8 @@ S9sOptions::printHelpControllers()
 "  --list                     To retrieve the list of stored controllers.\n"
 "  --print-deployment-info    Print all controllers, including static deployment info.\n"
 "  --add-controller           To create a new controller instance on specified host.\n"
+"  --add-db                   To join a host into the pool's cmon DB HA InnoDB Cluster\n"
+"                             as a SECONDARY (requires --nodes with exactly one node).\n"
 "  --assignment               To retrieve the controller assigned to specific cluster (requires --cluster-id).\n"
 "  --start                    To start a controller (requires --controller-id).\n"
 "  --stop                     To stop a controller (requires --controller-id).\n"
@@ -9050,7 +9064,9 @@ S9sOptions::printHelpControllers()
 "  --force                    With --set-max-clusters-capacity: allow a value that drops\n"
 "                             currently-owned clusters (a cap below the owned count, or 0 to\n"
 "                             go inactive); the pool thread abandons the affected clusters on\n"
-"                             its next cycle.\n"
+"                             its next cycle. With --add-db: proceed even if an existing,\n"
+"                             unrelated MySQL installation is detected on the target host\n"
+"                             (its data will be overwritten by the join).\n"
 "\n"
 "Job related options:\n"
 "  --log                      Wait and monitor job messages.\n"
@@ -19947,6 +19963,7 @@ S9sOptions::readOptionsControllers(
                     {"list",             no_argument, 0,       OptionControllersList},
                     {"print-deployment-info", no_argument, 0,  OptionPrintDeploymentInfo},
                     {"add-controller",   no_argument, 0,       OptionAddController},
+                    {"add-db",           no_argument, 0,       OptionAddDb},
                     {"assignment",       no_argument, 0,       OptionAssignedController},
                     {"set-pool-mode",   no_argument,  0,       OptionSetPoolMode},
                     {"unset-pool-mode", no_argument,  0,       OptionUnsetPoolMode},
@@ -20174,6 +20191,11 @@ S9sOptions::readOptionsControllers(
                 m_options["add_controller"] = true;
                 break;
 
+            case OptionAddDb:
+                // --add-db
+                m_options["add_db"] = true;
+                break;
+
             case OptionStartController:
                 // --start
                 m_options["start_controller"] = true;
@@ -20313,6 +20335,9 @@ S9sOptions::checkOptionsControllers()
         countOptions++;
 
     if (isAddController())
+        countOptions++;
+
+    if (isAddDb())
         countOptions++;
 
     if (isStartController())

--- a/libs9s/s9soptions.cpp
+++ b/libs9s/s9soptions.cpp
@@ -541,6 +541,7 @@ enum S9sOptionType
     OptionAddDb,
     OptionImportDb,
     OptionDeleteDb,
+    OptionListDb,
     OptionControllersList,
     OptionPrintDeploymentInfo,
     OptionAssignedController,
@@ -5668,6 +5669,18 @@ S9sOptions::isDeleteDb() const
 }
 
 /**
+ * \returns true if the "list-db" function is requested by providing the
+ * --list-db command line option (lists the pool's cmon DB HA InnoDB
+ * Cluster nodes via the read-only getCmonDbClusterNodes RPC call - not a
+ * job, unlike --add-db/--import-db/--delete-db).
+ */
+bool
+S9sOptions::isListDb() const
+{
+    return getBool("list_db");
+}
+
+/**
  * \returns true if the --start command line option was provided for controllers
  */
 bool
@@ -9064,6 +9077,9 @@ S9sOptions::printHelpControllers()
     printf(
 "Options for the \"pool-controllers\" command:\n"
 "  --list                     To retrieve the list of stored controllers.\n"
+"  --list-db                  To retrieve the list of the pool's cmon DB HA InnoDB\n"
+"                             Cluster nodes (read-only, no job is created). Supports\n"
+"                             --print-json like --list.\n"
 "  --print-deployment-info    Print all controllers, including static deployment info.\n"
 "  --add-controller           To create a new controller instance on specified host.\n"
 "  --add-db                   To join a host into the pool's cmon DB HA InnoDB Cluster\n"
@@ -19996,6 +20012,7 @@ S9sOptions::readOptionsControllers(
                     {"add-db",           no_argument, 0,       OptionAddDb},
                     {"import-db",        no_argument, 0,       OptionImportDb},
                     {"delete-db",        no_argument, 0,       OptionDeleteDb},
+                    {"list-db",          no_argument, 0,       OptionListDb},
                     {"assignment",       no_argument, 0,       OptionAssignedController},
                     {"set-pool-mode",   no_argument,  0,       OptionSetPoolMode},
                     {"unset-pool-mode", no_argument,  0,       OptionUnsetPoolMode},
@@ -20238,6 +20255,11 @@ S9sOptions::readOptionsControllers(
                 m_options["delete_db"] = true;
                 break;
 
+            case OptionListDb:
+                // --list-db
+                m_options["list_db"] = true;
+                break;
+
             case OptionStartController:
                 // --start
                 m_options["start_controller"] = true;
@@ -20386,6 +20408,9 @@ S9sOptions::checkOptionsControllers()
         countOptions++;
 
     if (isDeleteDb())
+        countOptions++;
+
+    if (isListDb())
         countOptions++;
 
     if (isStartController())

--- a/libs9s/s9soptions.h
+++ b/libs9s/s9soptions.h
@@ -551,6 +551,8 @@ class S9sOptions
         bool isUnsetPoolModeRequested() const;
         bool isAddController() const;
         bool isAddDb() const;
+        bool isImportDb() const;
+        bool isDeleteDb() const;
         bool isStartController() const;
         bool isStopController() const;
         bool isRemoveController() const;

--- a/libs9s/s9soptions.h
+++ b/libs9s/s9soptions.h
@@ -550,6 +550,7 @@ class S9sOptions
         bool isSetPoolModeRequested() const;
         bool isUnsetPoolModeRequested() const;
         bool isAddController() const;
+        bool isAddDb() const;
         bool isStartController() const;
         bool isStopController() const;
         bool isRemoveController() const;

--- a/libs9s/s9soptions.h
+++ b/libs9s/s9soptions.h
@@ -553,6 +553,7 @@ class S9sOptions
         bool isAddDb() const;
         bool isImportDb() const;
         bool isDeleteDb() const;
+        bool isListDb() const;
         bool isStartController() const;
         bool isStopController() const;
         bool isRemoveController() const;

--- a/libs9s/s9srpcclient.cpp
+++ b/libs9s/s9srpcclient.cpp
@@ -11740,6 +11740,61 @@ S9sRpcClient::addNewController(S9sOptions *options)
 }
 
 /**
+ * @brief join a bare host into the pool's cmon DB HA InnoDB Cluster as a
+ * SECONDARY (CmdAddCmonDbInstance / the addCmonDbInstance job).
+ *
+ * SSH credentials (ssh_user/ssh_keyfile/ssh_keydata/ssh_password, from the
+ * standard --os-user/--os-key-file/--os-password options) are already
+ * added to jobData by composeJobData() itself (via
+ * addCredentialsToJobData()), the same way every other node-adding command
+ * gets them - nothing extra needed here for that.
+ */
+bool
+S9sRpcClient::addNewCmonDbInstance(S9sOptions *options)
+{
+    const S9sString uri = "/v2/jobs/";
+    S9sVariantMap   request;
+
+    S9sVariantList hosts = options->nodes();
+
+    S9sVariantMap job     = composeJob();
+    S9sVariantMap jobData = composeJobData();
+    S9sVariantMap jobSpec;
+
+    if (hosts.size() == 1)
+    {
+        jobData["server_address"] = hosts[0].toNode().hostName();
+        // S9sNode::port() defaults to 0 when no ':port' was given on
+        // --nodes, unlike the addCmonDbInstance job's own 3306 default.
+        int port = hosts[0].toNode().port();
+        jobData["port"] = port > 0 ? port : 3306;
+    }
+    else
+    {
+        PRINT_ERROR(
+                "Exactly one node must specified for "
+                "addCmonDbInstance operation.");
+        options->setExitStatus(S9sOptions::BadOptions);
+        return false;
+    }
+
+    jobData["force"] = options->getBool("force");
+
+    // The jobspec describing the command.
+    jobSpec["command"]  = "addCmonDbInstance";
+    jobSpec["job_data"] = jobData;
+
+    // The job instance describing how the job will be executed.
+    job["job_spec"] = jobSpec;
+    job["title"]    = "Add DB Instance to Pool";
+
+    request["operation"] = "createJobInstance";
+    request["job"]       = job;
+
+    return executeRequest(uri, request);
+}
+
+/**
  * \returns true if the request was successfully sent
  *
  * Starts a controller instance

--- a/libs9s/s9srpcclient.cpp
+++ b/libs9s/s9srpcclient.cpp
@@ -11795,6 +11795,116 @@ S9sRpcClient::addNewCmonDbInstance(S9sOptions *options)
 }
 
 /**
+ * @brief import an existing, standalone cmon DB instance into the pool
+ * (CmdImportCmonDbInstance / the ImportCmonDbInstance job).
+ *
+ * Same job_data shape as addNewCmonDbInstance() - SSH credentials, when
+ * given via --os-user/--os-key-file/--os-password, flow through
+ * composeJobData() the same way.
+ */
+bool
+S9sRpcClient::importCmonDbInstance(S9sOptions *options)
+{
+    const S9sString uri = "/v2/jobs/";
+    S9sVariantMap   request;
+
+    S9sVariantList hosts = options->nodes();
+
+    S9sVariantMap job     = composeJob();
+    S9sVariantMap jobData = composeJobData();
+    S9sVariantMap jobSpec;
+
+    if (hosts.size() == 1)
+    {
+        jobData["server_address"] = hosts[0].toNode().hostName();
+        // S9sNode::port() defaults to 0 when no ':port' was given on
+        // --nodes, unlike the ImportCmonDbInstance job's own 3306 default.
+        int port = hosts[0].toNode().port();
+        jobData["port"] = port > 0 ? port : 3306;
+    }
+    else
+    {
+        PRINT_ERROR(
+                "Exactly one node must specified for "
+                "importCmonDbInstance operation.");
+        options->setExitStatus(S9sOptions::BadOptions);
+        return false;
+    }
+
+    jobData["force"] = options->getBool("force");
+
+    // The jobspec describing the command.
+    jobSpec["command"]  = "ImportCmonDbInstance";
+    jobSpec["job_data"] = jobData;
+
+    // The job instance describing how the job will be executed.
+    job["job_spec"] = jobSpec;
+    job["title"]    = "Import DB Instance to Pool";
+
+    request["operation"] = "createJobInstance";
+    request["job"]       = job;
+
+    return executeRequest(uri, request);
+}
+
+/**
+ * @brief remove a cmon DB instance from the pool's cmon DB HA InnoDB
+ * Cluster (CmdDeleteCmonDbInstance / the DeleteCmonDbInstance job).
+ *
+ * Uses composeJobData() the same way removeController() does for its own
+ * "remove something" job: SSH credentials are only added when the caller
+ * actually passed --os-user/--os-key-file/--os-password, so this stays
+ * harmless even though a delete typically does not need them - the
+ * server-side job decides whether it uses them, not this call.
+ *
+ * --force is meaningful here too: it mirrors mysqlsh's
+ * cluster.remove_instance(force) option, letting the instance be dropped
+ * from the cluster's metadata even when it cannot be reached.
+ */
+bool
+S9sRpcClient::deleteCmonDbInstance(S9sOptions *options)
+{
+    const S9sString uri = "/v2/jobs/";
+    S9sVariantMap   request;
+
+    S9sVariantList hosts = options->nodes();
+
+    S9sVariantMap job     = composeJob();
+    S9sVariantMap jobData = composeJobData();
+    S9sVariantMap jobSpec;
+
+    if (hosts.size() == 1)
+    {
+        jobData["server_address"] = hosts[0].toNode().hostName();
+        int port = hosts[0].toNode().port();
+        jobData["port"] = port > 0 ? port : 3306;
+    }
+    else
+    {
+        PRINT_ERROR(
+                "Exactly one node must specified for "
+                "deleteCmonDbInstance operation.");
+        options->setExitStatus(S9sOptions::BadOptions);
+        return false;
+    }
+
+    jobData["force"] = options->getBool("force");
+
+    // The jobspec describing the command.
+    jobSpec["command"]  = "DeleteCmonDbInstance";
+    jobSpec["job_data"] = jobData;
+
+    // The job instance describing how the job will be executed.
+    job["job_spec"] = jobSpec;
+    job["title"]    = "Delete DB Instance from Pool";
+
+    request["operation"] = "createJobInstance";
+    request["job"]       = job;
+
+    return executeRequest(uri, request);
+}
+
+/**
  * \returns true if the request was successfully sent
  *
  * Starts a controller instance

--- a/libs9s/s9srpcclient.cpp
+++ b/libs9s/s9srpcclient.cpp
@@ -11666,6 +11666,24 @@ S9sRpcClient::assignedController(S9sOptions *options)
 }
 
 /**
+ * @brief lists the pool's cmon DB HA InnoDB Cluster nodes
+ * (getCmonDbClusterNodes - a read-only query, unlike the job-creating
+ * addCmonDbInstance/ImportCmonDbInstance/DeleteCmonDbInstance calls).
+ *
+ * Mirrors listControllers()'s own wiring: same "/v2/poolcontrollers/"
+ * endpoint, same fire-and-render pattern (no job to wait on).
+ */
+bool
+S9sRpcClient::listDbClusterNodes(S9sOptions *options)
+{
+    const S9sString uri = "/v2/poolcontrollers/";
+    S9sVariantMap  request;
+    request["operation"] = "getcmondbclusternodes";
+
+    return executeRequest(uri, request);
+}
+
+/**
  * \returns set or unset pool mode on a specific controller
  */
 bool

--- a/libs9s/s9srpcclient.h
+++ b/libs9s/s9srpcclient.h
@@ -366,6 +366,7 @@ class S9sRpcClient
          * Requests related to controllers operations
          */
         bool listControllers(S9sOptions *options);
+        bool listDbClusterNodes(S9sOptions *options);
         bool assignedController(S9sOptions *options);
         bool setPoolMode(S9sOptions *options);
         bool addNewController(S9sOptions *options);

--- a/libs9s/s9srpcclient.h
+++ b/libs9s/s9srpcclient.h
@@ -369,6 +369,7 @@ class S9sRpcClient
         bool assignedController(S9sOptions *options);
         bool setPoolMode(S9sOptions *options);
         bool addNewController(S9sOptions *options);
+        bool addNewCmonDbInstance(S9sOptions *options);
         bool startController(S9sOptions *options);
         bool stopController(S9sOptions *options);
         bool removeController(S9sOptions *options);

--- a/libs9s/s9srpcclient.h
+++ b/libs9s/s9srpcclient.h
@@ -370,6 +370,8 @@ class S9sRpcClient
         bool setPoolMode(S9sOptions *options);
         bool addNewController(S9sOptions *options);
         bool addNewCmonDbInstance(S9sOptions *options);
+        bool importCmonDbInstance(S9sOptions *options);
+        bool deleteCmonDbInstance(S9sOptions *options);
         bool startController(S9sOptions *options);
         bool stopController(S9sOptions *options);
         bool removeController(S9sOptions *options);

--- a/libs9s/s9srpcreply.cpp
+++ b/libs9s/s9srpcreply.cpp
@@ -1988,6 +1988,91 @@ S9sRpcReply::printPoolControllersLong()
 
 }
 
+void
+S9sRpcReply::printCmonDbClusterNodes()
+{
+    printDebugMessages();
+    S9sOptions *options = S9sOptions::instance();
+    if (options->isJsonRequested())
+        printJsonFormat();
+    if (!isOk())
+        PRINT_ERROR("%s", STR(errorString()));
+    else
+        printCmonDbClusterNodesLong();
+}
+
+/**
+ * Lists the pool's cmon DB HA InnoDB Cluster nodes (read-only
+ * getCmonDbClusterNodes call, "pool-controllers --list-db").
+ *
+ * NOTE: the reply field names below ("nodes"/"hostname"/"port"/"role"/
+ * "status") are a best-effort match to the "controllers" list shape until
+ * the server-side reply is finalized - adjust here once it lands.
+ *
+ * \code
+ * s9s pool-controllers --list-db
+ * HOSTNAME  PORT ROLE      STATUS
+ * 10.0.0.11 3306 PRIMARY   ONLINE
+ * 10.0.0.12 3306 SECONDARY ONLINE
+ * \endcode
+ */
+void
+S9sRpcReply::printCmonDbClusterNodesLong()
+{
+    S9sOptions    *options = S9sOptions::instance();
+    S9sVariantList  nodes = operator[]("nodes").toVariantList();
+    if (nodes.size() == 0 && contains("node"))
+        nodes << operator[]("node").toVariantMap();
+
+    S9sFormat      hostnameFormat("\033[93m", TERM_NORMAL);
+    S9sFormat      portFormat("\033[94m", TERM_NORMAL);
+    S9sFormat      roleFormat("\033[94m", TERM_NORMAL);
+    S9sFormat      statusFormat("\033[94m", TERM_NORMAL);
+
+    // set width
+    for (const auto & n : nodes)
+    {
+        S9sVariantMap  w = n.toVariantMap();
+        S9sString      hostname = w["hostname"].toString();
+        S9sString      port     = w["port"].toString();
+        S9sString      role     = w["role"].toString();
+        S9sString      status   = w["status"].toString();
+
+        hostnameFormat.widen(hostname);
+        portFormat.widen(port);
+        roleFormat.widen(role);
+        statusFormat.widen(status);
+    }
+
+    // print header
+    if (!options->isNoHeaderRequested())
+    {
+        ::printf("%s", headerColorBegin());
+        hostnameFormat.printHeader("HOSTNAME");
+        portFormat.printHeader("PORT");
+        roleFormat.printHeader("ROLE");
+        statusFormat.printHeader("STATUS");
+        ::printf("%s", headerColorEnd());
+        ::printf("\n");
+    }
+
+    // print data
+    for (const auto & n : nodes)
+    {
+        S9sVariantMap  w = n.toVariantMap();
+        S9sString      hostname = w["hostname"].toString();
+        S9sString      port     = w["port"].toString();
+        S9sString      role     = w["role"].toString();
+        S9sString      status   = w["status"].toString();
+
+        hostnameFormat.printf(hostname);
+        portFormat.printf(port);
+        roleFormat.printf(role);
+        statusFormat.printf(status);
+        ::printf("\n");
+    }
+}
+
 
 
 void

--- a/libs9s/s9srpcreply.cpp
+++ b/libs9s/s9srpcreply.cpp
@@ -2005,29 +2005,39 @@ S9sRpcReply::printCmonDbClusterNodes()
  * Lists the pool's cmon DB HA InnoDB Cluster nodes (read-only
  * getCmonDbClusterNodes call, "pool-controllers --list-db").
  *
- * NOTE: the reply field names below ("nodes"/"hostname"/"port"/"role"/
- * "status") are a best-effort match to the "controllers" list shape until
- * the server-side reply is finalized - adjust here once it lands.
+ * The reply shape is intentionally minimal (CmonInnoDbClusterNodeHost
+ * records: hostname/port only - no role/status, since nothing monitors
+ * live member state for these records):
+ *
+ * \code{.js}
+ * {
+ *   "cmon_db_cluster_nodes": [
+ *     {"class_name": "CmonInnoDbClusterNodeHost", "cluster_id": 0,
+ *      "hostname": "10.0.1.42", "port": 3306},
+ *     ...
+ *   ],
+ *   "total": 2
+ * }
+ * \endcode
+ *
+ * class_name/cluster_id are internal bookkeeping, not surfaced in the
+ * plain-text table - they're still visible via --print-json.
  *
  * \code
  * s9s pool-controllers --list-db
- * HOSTNAME  PORT ROLE      STATUS
- * 10.0.0.11 3306 PRIMARY   ONLINE
- * 10.0.0.12 3306 SECONDARY ONLINE
+ * HOSTNAME  PORT
+ * 10.0.1.42 3306
+ * 10.0.1.87 3306
  * \endcode
  */
 void
 S9sRpcReply::printCmonDbClusterNodesLong()
 {
     S9sOptions    *options = S9sOptions::instance();
-    S9sVariantList  nodes = operator[]("nodes").toVariantList();
-    if (nodes.size() == 0 && contains("node"))
-        nodes << operator[]("node").toVariantMap();
+    S9sVariantList  nodes = operator[]("cmon_db_cluster_nodes").toVariantList();
 
     S9sFormat      hostnameFormat("\033[93m", TERM_NORMAL);
     S9sFormat      portFormat("\033[94m", TERM_NORMAL);
-    S9sFormat      roleFormat("\033[94m", TERM_NORMAL);
-    S9sFormat      statusFormat("\033[94m", TERM_NORMAL);
 
     // set width
     for (const auto & n : nodes)
@@ -2035,13 +2045,9 @@ S9sRpcReply::printCmonDbClusterNodesLong()
         S9sVariantMap  w = n.toVariantMap();
         S9sString      hostname = w["hostname"].toString();
         S9sString      port     = w["port"].toString();
-        S9sString      role     = w["role"].toString();
-        S9sString      status   = w["status"].toString();
 
         hostnameFormat.widen(hostname);
         portFormat.widen(port);
-        roleFormat.widen(role);
-        statusFormat.widen(status);
     }
 
     // print header
@@ -2050,8 +2056,6 @@ S9sRpcReply::printCmonDbClusterNodesLong()
         ::printf("%s", headerColorBegin());
         hostnameFormat.printHeader("HOSTNAME");
         portFormat.printHeader("PORT");
-        roleFormat.printHeader("ROLE");
-        statusFormat.printHeader("STATUS");
         ::printf("%s", headerColorEnd());
         ::printf("\n");
     }
@@ -2062,13 +2066,9 @@ S9sRpcReply::printCmonDbClusterNodesLong()
         S9sVariantMap  w = n.toVariantMap();
         S9sString      hostname = w["hostname"].toString();
         S9sString      port     = w["port"].toString();
-        S9sString      role     = w["role"].toString();
-        S9sString      status   = w["status"].toString();
 
         hostnameFormat.printf(hostname);
         portFormat.printf(port);
-        roleFormat.printf(role);
-        statusFormat.printf(status);
         ::printf("\n");
     }
 }

--- a/libs9s/s9srpcreply.h
+++ b/libs9s/s9srpcreply.h
@@ -157,7 +157,10 @@ class S9sRpcReply : public S9sVariantMap
 
         void printPoolControllers();
         void printPoolControllersLong();
-        
+
+        void printCmonDbClusterNodes();
+        void printCmonDbClusterNodesLong();
+
         // Methods handling users.
         void printUserList();
         void printUsersStat();

--- a/tests/ut_s9soptions/ut_s9soptions.cpp
+++ b/tests/ut_s9soptions/ut_s9soptions.cpp
@@ -64,6 +64,8 @@ UtS9sOptions::runTest(const char *testName)
     PERFORM_TEST(testConfigureWalOptions, retval);
     PERFORM_TEST(testAddController, retval);
     PERFORM_TEST(testAddDb, retval);
+    PERFORM_TEST(testImportDb, retval);
+    PERFORM_TEST(testDeleteDb, retval);
     PERFORM_TEST(testVirtualRouterId, retval);
     PERFORM_TEST(testRestoreClusterInfoOptions, retval);
 
@@ -886,6 +888,92 @@ UtS9sOptions::testAddDb()
     options = S9sOptions::instance();
     S9S_VERIFY(options->readOptions(&argc2, (char **)argv2));
     S9S_VERIFY(options->isAddDb());
+    S9S_VERIFY(options->getBool("force"));
+
+    S9sOptions::uninit();
+    return true;
+}
+
+bool
+UtS9sOptions::testImportDb()
+{
+    S9sOptions *options = S9sOptions::instance();
+
+    const char *argv1[] = { "/bin/s9s",
+                            "pool-controllers",
+                            "--import-db",
+                            "--nodes=10.16.186.1:3306",
+                            nullptr };
+    int         argc1   = sizeof(argv1) / sizeof(char *) - 1;
+
+    S9sOptions::uninit();
+    options = S9sOptions::instance();
+    S9S_VERIFY(options->readOptions(&argc1, (char **)argv1));
+    S9S_VERIFY(options->isImportDb());
+    S9S_COMPARE(options->nodes().size(), 1);
+    S9S_COMPARE(options->nodes()[0].toNode().hostName(), ("10.16.186.1"));
+    S9S_COMPARE(options->nodes()[0].toNode().port(), 3306);
+    S9S_VERIFY(!options->getBool("force"));
+
+    S9sOptions::uninit();
+
+    // --force must also be accepted and readable via the generic
+    // getBool("force") accessor, the same way importCmonDbInstance() reads
+    // it when building the job's job_data.
+    const char *argv2[] = { "/bin/s9s",
+                            "pool-controllers",
+                            "--import-db",
+                            "--nodes=10.16.186.1:3306",
+                            "--force",
+                            nullptr };
+    int         argc2   = sizeof(argv2) / sizeof(char *) - 1;
+
+    options = S9sOptions::instance();
+    S9S_VERIFY(options->readOptions(&argc2, (char **)argv2));
+    S9S_VERIFY(options->isImportDb());
+    S9S_VERIFY(options->getBool("force"));
+
+    S9sOptions::uninit();
+    return true;
+}
+
+bool
+UtS9sOptions::testDeleteDb()
+{
+    S9sOptions *options = S9sOptions::instance();
+
+    const char *argv1[] = { "/bin/s9s",
+                            "pool-controllers",
+                            "--delete-db",
+                            "--nodes=10.16.186.1:3306",
+                            nullptr };
+    int         argc1   = sizeof(argv1) / sizeof(char *) - 1;
+
+    S9sOptions::uninit();
+    options = S9sOptions::instance();
+    S9S_VERIFY(options->readOptions(&argc1, (char **)argv1));
+    S9S_VERIFY(options->isDeleteDb());
+    S9S_COMPARE(options->nodes().size(), 1);
+    S9S_COMPARE(options->nodes()[0].toNode().hostName(), ("10.16.186.1"));
+    S9S_COMPARE(options->nodes()[0].toNode().port(), 3306);
+    S9S_VERIFY(!options->getBool("force"));
+
+    S9sOptions::uninit();
+
+    // --force must also be accepted and readable via the generic
+    // getBool("force") accessor, the same way deleteCmonDbInstance() reads
+    // it when building the job's job_data.
+    const char *argv2[] = { "/bin/s9s",
+                            "pool-controllers",
+                            "--delete-db",
+                            "--nodes=10.16.186.1:3306",
+                            "--force",
+                            nullptr };
+    int         argc2   = sizeof(argv2) / sizeof(char *) - 1;
+
+    options = S9sOptions::instance();
+    S9S_VERIFY(options->readOptions(&argc2, (char **)argv2));
+    S9S_VERIFY(options->isDeleteDb());
     S9S_VERIFY(options->getBool("force"));
 
     S9sOptions::uninit();

--- a/tests/ut_s9soptions/ut_s9soptions.cpp
+++ b/tests/ut_s9soptions/ut_s9soptions.cpp
@@ -66,6 +66,7 @@ UtS9sOptions::runTest(const char *testName)
     PERFORM_TEST(testAddDb, retval);
     PERFORM_TEST(testImportDb, retval);
     PERFORM_TEST(testDeleteDb, retval);
+    PERFORM_TEST(testListDb, retval);
     PERFORM_TEST(testVirtualRouterId, retval);
     PERFORM_TEST(testRestoreClusterInfoOptions, retval);
 
@@ -975,6 +976,28 @@ UtS9sOptions::testDeleteDb()
     S9S_VERIFY(options->readOptions(&argc2, (char **)argv2));
     S9S_VERIFY(options->isDeleteDb());
     S9S_VERIFY(options->getBool("force"));
+
+    S9sOptions::uninit();
+    return true;
+}
+
+bool
+UtS9sOptions::testListDb()
+{
+    S9sOptions *options = S9sOptions::instance();
+
+    // --list-db is a read-only query: no --nodes required, unlike
+    // --add-db/--import-db/--delete-db.
+    const char *argv1[] = { "/bin/s9s",
+                            "pool-controllers",
+                            "--list-db",
+                            nullptr };
+    int         argc1   = sizeof(argv1) / sizeof(char *) - 1;
+
+    S9sOptions::uninit();
+    options = S9sOptions::instance();
+    S9S_VERIFY(options->readOptions(&argc1, (char **)argv1));
+    S9S_VERIFY(options->isListDb());
 
     S9sOptions::uninit();
     return true;

--- a/tests/ut_s9soptions/ut_s9soptions.cpp
+++ b/tests/ut_s9soptions/ut_s9soptions.cpp
@@ -63,6 +63,7 @@ UtS9sOptions::runTest(const char *testName)
     PERFORM_TEST(testExternalBackup, retval);
     PERFORM_TEST(testConfigureWalOptions, retval);
     PERFORM_TEST(testAddController, retval);
+    PERFORM_TEST(testAddDb, retval);
     PERFORM_TEST(testVirtualRouterId, retval);
     PERFORM_TEST(testRestoreClusterInfoOptions, retval);
 
@@ -839,6 +840,53 @@ UtS9sOptions::testAddController()
     S9S_COMPARE(options->nodes().size(), 1);
     S9S_COMPARE(options->nodes()[0].toNode().hostName(), ("10.16.186.1"));
     S9S_COMPARE(options->providerVersion(), "2.3.4-17176");
+
+    S9sOptions::uninit();
+    return true;
+}
+
+/**
+ * Testing the "pool-controllers --add-db" option (joins a bare host into
+ * the pool's cmon DB HA InnoDB Cluster via the addCmonDbInstance job).
+ */
+bool
+UtS9sOptions::testAddDb()
+{
+    S9sOptions *options = S9sOptions::instance();
+
+    const char *argv1[] = { "/bin/s9s",
+                            "pool-controllers",
+                            "--add-db",
+                            "--nodes=10.16.186.1:3306",
+                            nullptr };
+    int         argc1   = sizeof(argv1) / sizeof(char *) - 1;
+
+    S9sOptions::uninit();
+    options = S9sOptions::instance();
+    S9S_VERIFY(options->readOptions(&argc1, (char **)argv1));
+    S9S_VERIFY(options->isAddDb());
+    S9S_COMPARE(options->nodes().size(), 1);
+    S9S_COMPARE(options->nodes()[0].toNode().hostName(), ("10.16.186.1"));
+    S9S_COMPARE(options->nodes()[0].toNode().port(), 3306);
+    S9S_VERIFY(!options->getBool("force"));
+
+    S9sOptions::uninit();
+
+    // --force must also be accepted and readable via the generic
+    // getBool("force") accessor, the same way addNewCmonDbInstance() reads
+    // it when building the job's job_data.
+    const char *argv2[] = { "/bin/s9s",
+                            "pool-controllers",
+                            "--add-db",
+                            "--nodes=10.16.186.1:3306",
+                            "--force",
+                            nullptr };
+    int         argc2   = sizeof(argv2) / sizeof(char *) - 1;
+
+    options = S9sOptions::instance();
+    S9S_VERIFY(options->readOptions(&argc2, (char **)argv2));
+    S9S_VERIFY(options->isAddDb());
+    S9S_VERIFY(options->getBool("force"));
 
     S9sOptions::uninit();
     return true;

--- a/tests/ut_s9soptions/ut_s9soptions.h
+++ b/tests/ut_s9soptions/ut_s9soptions.h
@@ -49,6 +49,7 @@ class UtS9sOptions : public S9sUnitTest
         bool testAddDb();
         bool testImportDb();
         bool testDeleteDb();
+        bool testListDb();
         bool testVirtualRouterId();
         bool testRestoreClusterInfoOptions();
 };

--- a/tests/ut_s9soptions/ut_s9soptions.h
+++ b/tests/ut_s9soptions/ut_s9soptions.h
@@ -47,6 +47,8 @@ class UtS9sOptions : public S9sUnitTest
         bool testConfigureWalOptions();
         bool testAddController();
         bool testAddDb();
+        bool testImportDb();
+        bool testDeleteDb();
         bool testVirtualRouterId();
         bool testRestoreClusterInfoOptions();
 };

--- a/tests/ut_s9soptions/ut_s9soptions.h
+++ b/tests/ut_s9soptions/ut_s9soptions.h
@@ -46,6 +46,7 @@ class UtS9sOptions : public S9sUnitTest
         bool testExternalBackup();
         bool testConfigureWalOptions();
         bool testAddController();
+        bool testAddDb();
         bool testVirtualRouterId();
         bool testRestoreClusterInfoOptions();
 };

--- a/tests/ut_s9srpcclient/ut_s9srpcclient.cpp
+++ b/tests/ut_s9srpcclient/ut_s9srpcclient.cpp
@@ -171,6 +171,8 @@ UtS9sRpcClient::runTest(
     PERFORM_TEST(testConfigureWal, retval);
     PERFORM_TEST(testAddController, retval);
     PERFORM_TEST(testAddDb, retval);
+    PERFORM_TEST(testImportDb, retval);
+    PERFORM_TEST(testDeleteDb, retval);
 
     return retval;
 }
@@ -2939,6 +2941,112 @@ UtS9sRpcClient::testAddDb()
     options->m_options["force"] = true;
 
     S9S_VERIFY(client.addNewCmonDbInstance(options));
+    payload = client.lastPayload();
+
+    jobData = payload["job"]["job_spec"]["job_data"].toVariantMap();
+    S9S_COMPARE(jobData["server_address"], "10.0.1.87");
+    S9S_COMPARE(jobData["port"], 3306);
+    S9S_VERIFY(jobData["force"].toBoolean());
+
+    return true;
+}
+
+/**
+ * Testing importCmonDbInstance() (the "pool-controllers --import-db" job -
+ * CmdImportCmonDbInstance) request shape: job_spec.command, and job_data's
+ * server_address/port/force fields.
+ */
+bool
+UtS9sRpcClient::testImportDb()
+{
+    S9sOptions         *options = S9sOptions::instance();
+    S9sRpcClientTester  client;
+    S9sVariantMap       payload;
+    S9sVariantMap       jobData;
+
+    // Explicit port, force omitted (must default to false).
+    S9sOptions::uninit();
+    options = S9sOptions::instance();
+    options->setNodes("10.0.1.87:3307");
+
+    S9S_VERIFY(client.importCmonDbInstance(options));
+    payload = client.lastPayload();
+
+    if (isVerbose())
+        printDebug(payload);
+
+    S9S_COMPARE(payload["operation"], "createJobInstance");
+    S9S_COMPARE(
+            payload.valueByPath("/job/job_spec/command").toString(),
+            "ImportCmonDbInstance");
+
+    jobData = payload["job"]["job_spec"]["job_data"].toVariantMap();
+    S9S_COMPARE(jobData["server_address"], "10.0.1.87");
+    S9S_COMPARE(jobData["port"], 3307);
+    S9S_VERIFY(!jobData["force"].toBoolean());
+
+    // No port on --nodes -> must default to 3306 (S9sNode::port() itself
+    // defaults to 0, not 3306, so importCmonDbInstance() must apply the
+    // fallback itself). --force must also come through.
+    S9sOptions::uninit();
+    options = S9sOptions::instance();
+    options->setNodes("10.0.1.87");
+    options->m_options["force"] = true;
+
+    S9S_VERIFY(client.importCmonDbInstance(options));
+    payload = client.lastPayload();
+
+    jobData = payload["job"]["job_spec"]["job_data"].toVariantMap();
+    S9S_COMPARE(jobData["server_address"], "10.0.1.87");
+    S9S_COMPARE(jobData["port"], 3306);
+    S9S_VERIFY(jobData["force"].toBoolean());
+
+    return true;
+}
+
+/**
+ * Testing deleteCmonDbInstance() (the "pool-controllers --delete-db" job -
+ * CmdDeleteCmonDbInstance) request shape: job_spec.command, and job_data's
+ * server_address/port/force fields.
+ */
+bool
+UtS9sRpcClient::testDeleteDb()
+{
+    S9sOptions         *options = S9sOptions::instance();
+    S9sRpcClientTester  client;
+    S9sVariantMap       payload;
+    S9sVariantMap       jobData;
+
+    // Explicit port, force omitted (must default to false).
+    S9sOptions::uninit();
+    options = S9sOptions::instance();
+    options->setNodes("10.0.1.87:3307");
+
+    S9S_VERIFY(client.deleteCmonDbInstance(options));
+    payload = client.lastPayload();
+
+    if (isVerbose())
+        printDebug(payload);
+
+    S9S_COMPARE(payload["operation"], "createJobInstance");
+    S9S_COMPARE(
+            payload.valueByPath("/job/job_spec/command").toString(),
+            "DeleteCmonDbInstance");
+
+    jobData = payload["job"]["job_spec"]["job_data"].toVariantMap();
+    S9S_COMPARE(jobData["server_address"], "10.0.1.87");
+    S9S_COMPARE(jobData["port"], 3307);
+    S9S_VERIFY(!jobData["force"].toBoolean());
+
+    // No port on --nodes -> must default to 3306 (S9sNode::port() itself
+    // defaults to 0, not 3306, so deleteCmonDbInstance() must apply the
+    // fallback itself). --force must also come through.
+    S9sOptions::uninit();
+    options = S9sOptions::instance();
+    options->setNodes("10.0.1.87");
+    options->m_options["force"] = true;
+
+    S9S_VERIFY(client.deleteCmonDbInstance(options));
     payload = client.lastPayload();
 
     jobData = payload["job"]["job_spec"]["job_data"].toVariantMap();

--- a/tests/ut_s9srpcclient/ut_s9srpcclient.cpp
+++ b/tests/ut_s9srpcclient/ut_s9srpcclient.cpp
@@ -173,6 +173,7 @@ UtS9sRpcClient::runTest(
     PERFORM_TEST(testAddDb, retval);
     PERFORM_TEST(testImportDb, retval);
     PERFORM_TEST(testDeleteDb, retval);
+    PERFORM_TEST(testListDb, retval);
 
     return retval;
 }
@@ -3053,6 +3054,33 @@ UtS9sRpcClient::testDeleteDb()
     S9S_COMPARE(jobData["server_address"], "10.0.1.87");
     S9S_COMPARE(jobData["port"], 3306);
     S9S_VERIFY(jobData["force"].toBoolean());
+
+    return true;
+}
+
+/**
+ * Testing listDbClusterNodes() (the "pool-controllers --list-db" call -
+ * the read-only getCmonDbClusterNodes RPC) request shape: unlike
+ * add/import/deleteCmonDbInstance this is not a job, just a flat request
+ * with the operation name.
+ */
+bool
+UtS9sRpcClient::testListDb()
+{
+    S9sOptions         *options = S9sOptions::instance();
+    S9sRpcClientTester  client;
+    S9sVariantMap       payload;
+
+    S9sOptions::uninit();
+    options = S9sOptions::instance();
+
+    S9S_VERIFY(client.listDbClusterNodes(options));
+    payload = client.lastPayload();
+
+    if (isVerbose())
+        printDebug(payload);
+
+    S9S_COMPARE(payload["operation"], "getcmondbclusternodes");
 
     return true;
 }

--- a/tests/ut_s9srpcclient/ut_s9srpcclient.cpp
+++ b/tests/ut_s9srpcclient/ut_s9srpcclient.cpp
@@ -170,6 +170,7 @@ UtS9sRpcClient::runTest(
 
     PERFORM_TEST(testConfigureWal, retval);
     PERFORM_TEST(testAddController, retval);
+    PERFORM_TEST(testAddDb, retval);
 
     return retval;
 }
@@ -2891,6 +2892,59 @@ UtS9sRpcClient::testAddController()
     S9S_COMPARE(jobData["version"], "2.3.4-17176");
     S9S_COMPARE(jobData["server_address"], "10.16.186.1");
     S9S_COMPARE(jobData["port"], 9500);
+
+    return true;
+}
+
+/**
+ * Testing addNewCmonDbInstance() (the "pool-controllers --add-db" job -
+ * CmdAddCmonDbInstance) request shape: job_spec.command, and job_data's
+ * server_address/port/force fields.
+ */
+bool
+UtS9sRpcClient::testAddDb()
+{
+    S9sOptions         *options = S9sOptions::instance();
+    S9sRpcClientTester  client;
+    S9sVariantMap       payload;
+    S9sVariantMap       jobData;
+
+    // Explicit port, force omitted (must default to false).
+    S9sOptions::uninit();
+    options = S9sOptions::instance();
+    options->setNodes("10.0.1.87:3307");
+
+    S9S_VERIFY(client.addNewCmonDbInstance(options));
+    payload = client.lastPayload();
+
+    if (isVerbose())
+        printDebug(payload);
+
+    S9S_COMPARE(payload["operation"], "createJobInstance");
+    S9S_COMPARE(
+            payload.valueByPath("/job/job_spec/command").toString(),
+            "addCmonDbInstance");
+
+    jobData = payload["job"]["job_spec"]["job_data"].toVariantMap();
+    S9S_COMPARE(jobData["server_address"], "10.0.1.87");
+    S9S_COMPARE(jobData["port"], 3307);
+    S9S_VERIFY(!jobData["force"].toBoolean());
+
+    // No port on --nodes -> must default to 3306 (S9sNode::port() itself
+    // defaults to 0, not 3306, so addNewCmonDbInstance() must apply the
+    // fallback itself). --force must also come through.
+    S9sOptions::uninit();
+    options = S9sOptions::instance();
+    options->setNodes("10.0.1.87");
+    options->m_options["force"] = true;
+
+    S9S_VERIFY(client.addNewCmonDbInstance(options));
+    payload = client.lastPayload();
+
+    jobData = payload["job"]["job_spec"]["job_data"].toVariantMap();
+    S9S_COMPARE(jobData["server_address"], "10.0.1.87");
+    S9S_COMPARE(jobData["port"], 3306);
+    S9S_VERIFY(jobData["force"].toBoolean());
 
     return true;
 }

--- a/tests/ut_s9srpcclient/ut_s9srpcclient.h
+++ b/tests/ut_s9srpcclient/ut_s9srpcclient.h
@@ -110,6 +110,7 @@ class UtS9sRpcClient : public S9sUnitTest
 
         bool testConfigureWal();
         bool testAddController();
+        bool testAddDb();
 };
 
 class S9sRpcClientTester : public S9sRpcClient

--- a/tests/ut_s9srpcclient/ut_s9srpcclient.h
+++ b/tests/ut_s9srpcclient/ut_s9srpcclient.h
@@ -111,6 +111,8 @@ class UtS9sRpcClient : public S9sUnitTest
         bool testConfigureWal();
         bool testAddController();
         bool testAddDb();
+        bool testImportDb();
+        bool testDeleteDb();
 };
 
 class S9sRpcClientTester : public S9sRpcClient

--- a/tests/ut_s9srpcclient/ut_s9srpcclient.h
+++ b/tests/ut_s9srpcclient/ut_s9srpcclient.h
@@ -113,6 +113,7 @@ class UtS9sRpcClient : public S9sUnitTest
         bool testAddDb();
         bool testImportDb();
         bool testDeleteDb();
+        bool testListDb();
 };
 
 class S9sRpcClientTester : public S9sRpcClient


### PR DESCRIPTION
## Summary
- Adds `s9s pool-controllers --add-db --nodes=<host[:port]>`, which creates a `CmdAddCmonDbInstance` job (joins a bare host into the pool's cmon DB HA InnoDB Cluster as a SECONDARY) — mirroring `--add-controller`'s existing `CmdAddController` wiring exactly.
- `S9sRpcClient::addNewCmonDbInstance()`: `POST /v2/jobs/`, `operation=createJobInstance`, `job_spec.command="addCmonDbInstance"`, `job_data={server_address, port, force}`. SSH credentials flow through the existing shared `composeJobData()`/`addCredentialsToJobData()` path, same as every other node-adding command — no new credential wiring needed.
- `--force` reuses the existing generic `pool-controllers` option, read via `options->getBool("force")`.
- Help text added for `--add-db`, extended for `--force`'s addCmonDbInstance-specific meaning.

Depends on clustercontrol-enterprise PR #3514 (CmdAddCmonDbInstance itself) and pairs with s9s-cmon-test PR #1226 (functional test coverage), which now uses this CLI instead of a raw RPC call.

## Test plan
- [x] `ut_s9soptions::testAddDb` — flag parsing, node/port parsing, `--force` readback (9 checks)
- [x] `ut_s9srpcclient::testAddDb` — actual RPC payload shape, explicit-port and default-port/force paths (15 checks)
- [x] Full `tests/runalltests.sh` — all unit tests pass, including both new ones
- [x] Manual CLI checks: `--help` output, missing `--nodes` error path, `--add-db` combined with another main option error path
- [x] Independently re-verified by re-running both new test binaries directly against the current committed source

🤖 Generated with [Claude Code](https://claude.com/claude-code)