### PR TITLE
CLUS-8347: Add --auto-agent to leave agent deployment to the controller

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -22,6 +22,10 @@ s9s-tools (1.9.2026011315-release1) UNRELEASED; urgency=medium
     referenced by a registered cloud credential, on add-node, reconfigure
     and reinstall.
 
+  [ Aliaksei Zhordachkin ]
+  * Added --auto-agent option for create cluster jobs to leave the agent
+    installation decision to the controller.
+
  -- Peter Csaszar <peter@severalnines.com>  Tue, 13 Jan 2026 15:21:55 +0100
 
 s9s-tools (1.9.2025061016-testingubuntu1) unstable; urgency=medium

--- a/doc/s9s-cluster.1
+++ b/doc/s9s-cluster.1
@@ -294,6 +294,25 @@ s9s cluster \\
 .fi
 
 .TP
+.B \-\-auto-agent
+When creating a new cluster this option leaves the decision about the agent
+installation to the controller instead of requesting or refusing it. Without
+this option the client always asks for the agents to be installed, unless
+\fB\-\-no-agent\fP is provided.
+
+.B EXAMPLE
+.nf
+s9s cluster \\
+    --create \\
+    --cluster-type=postgresql \\
+    --nodes="10.67.199.164" \\
+    --db-admin=postgres \\
+    --db-admin-passwd=secret \\
+    --provider-version=17 \\
+    --auto-agent
+.fi
+
+.TP
 .B --create-report
 When this command line option is provided a new job will be started that will
 create an error-report. After the job is executed the error-report will be

--- a/doc/s9s_completion
+++ b/doc/s9s_completion
@@ -190,6 +190,7 @@ function _s9s()
                 opts+="--remote-cluster-id= "
 
                 opts+="--account= "
+                opts+="--auto-agent "
                 opts+="--cloud= "
                 opts+="--cluster-format= "
                 opts+="--cluster-name= "
@@ -205,6 +206,7 @@ function _s9s()
                 opts+="--image= "
                 opts+="--image-os-user= "
                 opts+="--job-tags= "
+                opts+="--no-agent "
                 opts+="--nodes= "
                 opts+="--opt-group= "
                 opts+="--opt-name= "

--- a/libs9s/s9soptions.cpp
+++ b/libs9s/s9soptions.cpp
@@ -313,6 +313,7 @@ enum S9sOptionType
     OptionDisableSsl,
     OptionCreateReport,
     OptionNoAgent,
+    OptionAutoAgent,
     OptionMaskPasswords,
     OptionDeployAgents,
     OptionDeployCmonAgents,
@@ -3399,6 +3400,15 @@ bool
 S9sOptions::noAgent() const
 {
     return getBool("no_agent");
+}
+
+/**
+ * \returns true if the --auto-agent command line option was provided.
+ */
+bool
+S9sOptions::autoAgent() const
+{
+    return getBool("auto_agent");
 }
 
 /**
@@ -8530,6 +8540,7 @@ S9sOptions::printHelpCluster()
 "\n"
 " Options for cluster creation\n"
 "  --no-agent                 Do not install prometheus agents during create cluster.\n"
+"  --auto-agent               Let the prometheus agent deployment be decided automatically.\n"
 "\n"
 "Add replication node related options\n"
 "  --master-delay             Delay in seconds to be set on replica node\n"
@@ -15297,6 +15308,7 @@ S9sOptions::readOptionsCluster(
 
         // Options for cluster creation
         { "no-agent",         no_argument,    0, OptionNoAgent            },
+        { "auto-agent",       no_argument,    0, OptionAutoAgent          },
 
         // Option(s) for error-report generation
         { "mask-passwords",   no_argument,       0, OptionMaskPasswords   },
@@ -15619,6 +15631,11 @@ S9sOptions::readOptionsCluster(
             case OptionNoAgent:
                 // --no-agent
                 m_options["no_agent"] = true;
+                break;
+
+            case OptionAutoAgent:
+                // --auto-agent
+                m_options["auto_agent"] = true;
                 break;
 
             case OptionMaskPasswords:

--- a/libs9s/s9soptions.h
+++ b/libs9s/s9soptions.h
@@ -402,6 +402,7 @@ class S9sOptions
         S9sString optValue() const;
         S9sString outputDir() const;
         bool noAgent() const;
+        bool autoAgent() const;
         bool maskPasswords() const;
         S9sString donor() const;
         S9sString templateName() const;

--- a/libs9s/s9srpcclient.cpp
+++ b/libs9s/s9srpcclient.cpp
@@ -3542,6 +3542,17 @@ S9sRpcClient::getStats(
 }
 
 
+// Omitted on --auto-agent so the controller applies its own default.
+static void
+setDeployAgentsIfRequested(
+        S9sVariantMap &jobData)
+{
+    S9sOptions *options = S9sOptions::instance();
+    if (!options->autoAgent())
+        jobData["deploy_agents"] = !options->noAgent();
+}
+
+
 /**
  * \param hosts the hosts that will be the member of the cluster (variant list
  *   with S9sNode elements).
@@ -3584,7 +3595,7 @@ S9sRpcClient::createGaleraCluster(
     jobData["mysql_password"]   = options->dbAdminPassword();
     jobData["mysql_user"]       = options->dbAdminUserName();
     jobData["disable_firewall"] = !options->keepFirewall();
-    jobData["deploy_agents"]    = !options->noAgent();
+    setDeployAgentsIfRequested(jobData);
 
     if (options->hasSemiSync())
         jobData["mysql_semi_sync"] = options->isSemiSync();
@@ -3666,7 +3677,7 @@ S9sRpcClient::createMySqlSingleCluster(
     jobData["mysql_user"]       = options->dbAdminUserName();
     jobData["mysql_password"]   = options->dbAdminPassword();
     jobData["disable_firewall"] = !options->keepFirewall();
-    jobData["deploy_agents"]    = !options->noAgent();
+    setDeployAgentsIfRequested(jobData);
 
     if (options->hasSemiSync())
         jobData["mysql_semi_sync"] = options->isSemiSync();
@@ -3966,7 +3977,7 @@ S9sRpcClient::createMySqlReplication(
     jobData["mysql_user"]       = options->dbAdminUserName();
     jobData["mysql_password"]   = options->dbAdminPassword();
     jobData["disable_firewall"] = !options->keepFirewall();
-    jobData["deploy_agents"]    = !options->noAgent();
+    setDeployAgentsIfRequested(jobData);
 
     if (options->hasSemiSync())
         jobData["mysql_semi_sync"] = options->isSemiSync();
@@ -4130,7 +4141,7 @@ S9sRpcClient::createGroupReplication(
     jobData["mysql_user"]       = options->dbAdminUserName();
     jobData["mysql_password"]   = options->dbAdminPassword();
     jobData["disable_firewall"] = !options->keepFirewall();
-    jobData["deploy_agents"]    = !options->noAgent();
+    setDeployAgentsIfRequested(jobData);
 
     if (options->hasSemiSync())
         jobData["mysql_semi_sync"] = options->isSemiSync();
@@ -4290,7 +4301,7 @@ S9sRpcClient::createNdbCluster(
     jobData["version"]          = mySqlVersion;
     jobData["disable_selinux"]  = true;
     jobData["disable_firewall"] = !options->keepFirewall();
-    jobData["deploy_agents"]    = !options->noAgent();
+    setDeployAgentsIfRequested(jobData);
 
     // --ndb-data-memory-ratio=RATIO -- forwarded to cmon as
     // /job_data/ndb_data_memory_ratio so the auto-calculated NDB
@@ -4484,7 +4495,7 @@ S9sRpcClient::createPostgreSql(
     jobData["postgre_user"]     = options->dbAdminUserName();
     jobData["postgre_password"] = options->dbAdminPassword();
     jobData["disable_firewall"] = !options->keepFirewall();
-    jobData["deploy_agents"]    = !options->noAgent();
+    setDeployAgentsIfRequested(jobData);
     if (!options->extensions().empty())
         jobData["pg_extensions"]     = options->extensions();
 
@@ -4863,7 +4874,7 @@ S9sRpcClient::createRedisOrValkeySharded(
     jobData["db_user"]          = options->dbAdminUserName();
     jobData["db_password"]      = options->dbAdminPassword();
     jobData["disable_firewall"] = !options->keepFirewall();
-    jobData["deploy_agents"]    = !options->noAgent();
+    setDeployAgentsIfRequested(jobData);
 
     if (options->noInstall())
     {
@@ -4957,7 +4968,7 @@ S9sRpcClient::createRedisOrValkeySentinel(
     jobData["db_user"]          = options->dbAdminUserName();
     jobData["db_password"]      = options->dbAdminPassword();
     jobData["disable_firewall"] = !options->keepFirewall();
-    jobData["deploy_agents"]    = !options->noAgent();
+    setDeployAgentsIfRequested(jobData);
 
     if (options->noInstall())
     {
@@ -5033,7 +5044,7 @@ S9sRpcClient::createElasticsearch(
     jobData["db_user"]          = options->dbAdminUserName();
     jobData["db_password"]      = options->dbAdminPassword();
     jobData["disable_firewall"] = !options->keepFirewall();
-    jobData["deploy_agents"]    = !options->noAgent();
+    setDeployAgentsIfRequested(jobData);
 
     if (options->noInstall())
     {
@@ -5095,7 +5106,7 @@ S9sRpcClient::createClickHouseCluster(
     jobData["db_user"]          = options->dbAdminUserName();
     jobData["db_password"]      = options->dbAdminPassword();
     jobData["disable_firewall"] = !options->keepFirewall();
-    jobData["deploy_agents"]    = !options->noAgent();
+    setDeployAgentsIfRequested(jobData);
 
     if (options->hasProviderVersion())
         jobData["version"]      = version;
@@ -5164,7 +5175,7 @@ S9sRpcClient::createMsSqlSingle(
     jobData["db_user"]          = options->dbAdminUserName();
     jobData["db_password"]      = options->dbAdminPassword();
     jobData["disable_firewall"] = !options->keepFirewall();
-    jobData["deploy_agents"]    = !options->noAgent();
+    setDeployAgentsIfRequested(jobData);
 
     if (options->noInstall())
     {
@@ -5246,7 +5257,7 @@ S9sRpcClient::createMongoCluster(
     jobData["mongodb_user"]     = options->dbAdminUserName();
     jobData["mongodb_password"] = options->dbAdminPassword();
     jobData["disable_firewall"] = !options->keepFirewall();
-    jobData["deploy_agents"]    = !options->noAgent();
+    setDeployAgentsIfRequested(jobData);
    
     if (options->noInstall())
     {
@@ -8238,7 +8249,7 @@ S9sRpcClient::checkHosts()
         jobData["nodes"]          = nodesField(hosts);
         jobData["vendor"]         = options->vendor();
         jobData["version"]        = options->providerVersion();
-        jobData["deploy_agents"]  = !options->noAgent();
+        setDeployAgentsIfRequested(jobData);
     
         jobSpec["command"]        = "create_cluster";
         jobSpec["job_data"]       = jobData;

--- a/tests/ut_s9srpcclient/ut_s9srpcclient.cpp
+++ b/tests/ut_s9srpcclient/ut_s9srpcclient.cpp
@@ -145,6 +145,9 @@ UtS9sRpcClient::runTest(
     PERFORM_TEST(testCreateServer,        retval);
     PERFORM_TEST(testSetHost,             retval);
     PERFORM_TEST(testCreateGalera,        retval);
+    PERFORM_TEST(testDeployAgentsDefault, retval);
+    PERFORM_TEST(testDeployAgentsNoAgent, retval);
+    PERFORM_TEST(testDeployAgentsAutoAgent, retval);
     PERFORM_TEST(testCreateReplication,   retval);
     PERFORM_TEST(testCreateNdbCluster,    retval);
     PERFORM_TEST(testAddNode,             retval);
@@ -1690,6 +1693,73 @@ UtS9sRpcClient::testCreateGalera()
     S9S_VERIFY(payload.contains("\"version\": \"5.6\""));
     S9S_VERIFY(payload.contains("\"hostname\": \"192.168.1.193\""));
 
+    return true;
+}
+
+/**
+ * Checking that a plain create cluster asks for the agents.
+ */
+bool
+UtS9sRpcClient::testDeployAgentsDefault()
+{
+    S9sRpcClientTester client;
+    S9sVariantList     hosts;
+    S9sString          payload;
+
+    hosts << S9sNode("192.168.1.191");
+
+    S9S_VERIFY(client.createGaleraCluster(hosts, "pi", "percona", "5.6"));
+    payload = client.payload(0u);
+
+    S9S_VERIFY(payload.contains("\"deploy_agents\": true"));
+
+    S9sOptions::uninit();
+    return true;
+}
+
+/**
+ * Checking that --no-agent refuses the agents.
+ */
+bool
+UtS9sRpcClient::testDeployAgentsNoAgent()
+{
+    S9sOptions        *options = S9sOptions::instance();
+    S9sRpcClientTester client;
+    S9sVariantList     hosts;
+    S9sString          payload;
+
+    options->m_options["no_agent"] = true;
+    hosts << S9sNode("192.168.1.191");
+
+    S9S_VERIFY(client.createGaleraCluster(hosts, "pi", "percona", "5.6"));
+    payload = client.payload(0u);
+
+    S9S_VERIFY(payload.contains("\"deploy_agents\": false"));
+
+    S9sOptions::uninit();
+    return true;
+}
+
+/**
+ * Checking that --auto-agent leaves the key out of the request.
+ */
+bool
+UtS9sRpcClient::testDeployAgentsAutoAgent()
+{
+    S9sOptions        *options = S9sOptions::instance();
+    S9sRpcClientTester client;
+    S9sVariantList     hosts;
+    S9sString          payload;
+
+    options->m_options["auto_agent"] = true;
+    hosts << S9sNode("192.168.1.191");
+
+    S9S_VERIFY(client.createGaleraCluster(hosts, "pi", "percona", "5.6"));
+    payload = client.payload(0u);
+
+    S9S_VERIFY(!payload.contains("deploy_agents"));
+
+    S9sOptions::uninit();
     return true;
 }
 

--- a/tests/ut_s9srpcclient/ut_s9srpcclient.h
+++ b/tests/ut_s9srpcclient/ut_s9srpcclient.h
@@ -85,6 +85,9 @@ class UtS9sRpcClient : public S9sUnitTest
         bool testCreateServer();
         bool testSetHost();
         bool testCreateGalera();
+        bool testDeployAgentsDefault();
+        bool testDeployAgentsNoAgent();
+        bool testDeployAgentsAutoAgent();
         bool testCreateReplication();
         bool testCreateNdbCluster();
         bool testAddNode();


### PR DESCRIPTION
`s9s cluster --create` always sent an explicit `deploy_agents` value, so there
was no way to let the controller decide. `--auto-agent` omits the key instead.

| Invocation     | `deploy_agents`     |
| -------------- | ------------------- |
| no flag        | `true` (unchanged)  |
| `--no-agent`   | `false` (unchanged) |
| `--auto-agent` | key omitted         |

Default behaviour is unchanged. Man page, bash completion and changelog updated.

Depends on the controller-side change in clustercontrol-enterprise under the
same ticket: until that lands, an omitted key is treated as `false`.
