### PR TITLE
CLUS-8329: report when a backup expires in s9s backup --list

### DIFF
--- a/doc/s9s-backup.1
+++ b/doc/s9s-backup.1
@@ -840,7 +840,8 @@ The verification status of the backup. Possible values are "Unverified",
 
 .TP
 .B x
-The date and time when the controller will delete the backup, formatted as the
+The same value the EXPIRES column of the long backup list shows: the date and
+time when the controller will delete the backup, formatted as the
 \fB\-\-date\-format\fP asks for. The word "NEVER" is shown for a backup the
 controller keeps forever, and "-" when the controller does not report an expiry
 at all, which is the case for controllers older than this field. A date in the

--- a/doc/s9s-backup.1
+++ b/doc/s9s-backup.1
@@ -839,6 +839,21 @@ The verification status of the backup. Possible values are "Unverified",
 "Verified" and "Failed".
 
 .TP
+.B x
+The date and time when the controller will delete the backup, formatted as the
+\fB\-\-date\-format\fP asks for. The word "NEVER" is shown for a backup the
+controller keeps forever, and "-" when the controller does not report an expiry
+at all, which is the case for controllers older than this field. A date in the
+past means the backup is eligible for deletion and the controller has not swept
+it yet - or is keeping it on purpose, see the "X" field.
+
+.TP
+.B X
+The word "KEPT" when the controller found the backup past its retention and kept
+it anyway, to honour the cluster's minimum number of backups
+(backup_n_safety_copies), "-" otherwise.
+
+.TP
 .B %
 The percent sign itself. Use two percent signs, "%%" the same way the standard
 printf() function interprets it as one percent sign.

--- a/doc/s9s-backup.1
+++ b/doc/s9s-backup.1
@@ -844,7 +844,7 @@ The same value the EXPIRES column of the long backup list shows: the date and
 time when the controller will delete the backup, formatted as the
 \fB\-\-date\-format\fP asks for. The word "NEVER" is shown for a backup the
 controller keeps forever, and "-" when the controller does not report an expiry
-at all, which is the case for controllers older than this field. A date in the
+at all - an older controller, from before the feature. A date in the
 past means the backup is eligible for deletion and the controller has not swept
 it yet - or is keeping it on purpose, see the "X" field.
 

--- a/libs9s/s9sbackup.cpp
+++ b/libs9s/s9sbackup.cpp
@@ -343,6 +343,72 @@ S9sBackup::endAsString() const
 }
 
 /**
+ * \returns When the controller will delete this backup, as the controller
+ *   reports it, or the empty variant when it does not report it at all.
+ *
+ * Read flat, the way begin() and end() are: s9s asks getBackups without a
+ * backup_record_version, so the reply is the flat record and not the version 2
+ * one that nests everything under "metadata".
+ */
+S9sVariant
+S9sBackup::expires() const
+{
+    if (m_properties.contains("expires"))
+        return m_properties.at("expires");
+
+    return S9sVariant();
+}
+
+/**
+ * \returns The expiry formatted as the command line options ask for, "NEVER"
+ *   for a backup the controller keeps forever, or "-" when there is no answer.
+ *
+ * The three cases are not interchangeable, and only the controller can tell
+ * them apart. An empty string is its way of saying "never deleted" - it knows
+ * the retention and it resolved to keep-forever - while an absent field means
+ * this controller does not report expiries at all, and one that cannot be
+ * parsed means we would be inventing a date. A blank column for all three would
+ * read as "no retention" for a backup that has one.
+ */
+S9sString
+S9sBackup::expiresAsString() const
+{
+    S9sOptions  *options   = S9sOptions::instance();
+    S9sVariant   value     = expires();
+    S9sString    rawString = value.toString();
+    S9sDateTime  expiry;
+
+    if (value.isInvalid())
+        return "-";
+
+    if (rawString.empty())
+        return "NEVER";
+
+    if (!expiry.parse(rawString))
+        return "-";
+
+    return options->formatDateTime(expiry);
+}
+
+/**
+ * \returns True when the controller found this backup past its retention and
+ *   kept it anyway, to honour backup_n_safety_copies.
+ *
+ * This is why an expiry in the past is not a contradiction: the date says when
+ * the backup became eligible for deletion, this says the housekeeping looked at
+ * it and declined. Only the controller can answer it - the rule counts and
+ * orders the cluster's viable backups.
+ */
+bool
+S9sBackup::retainedBySafetyCopies() const
+{
+    if (m_properties.contains("retained_by_safety_copies"))
+        return m_properties.at("retained_by_safety_copies").toBoolean();
+
+    return false;
+}
+
+/**
  * \returns The absolute path of the root directory where these backup files are
  * placed.
  */
@@ -869,6 +935,23 @@ S9sBackup::toString(
                     // The verification status.
                     partFormat += 's';
                     tmp.sprintf(STR(partFormat), STR(verificationStatus()));
+                    retval += tmp;
+                    break;
+
+                case 'x':
+                    // When the controller will delete this backup.
+                    partFormat += 's';
+                    tmp.sprintf(STR(partFormat), STR(expiresAsString()));
+                    retval += tmp;
+                    break;
+
+                case 'X':
+                    // Expired, but kept for the safety copies rule.
+                    partFormat += 's';
+
+                    tmp.sprintf(STR(partFormat),
+                            retainedBySafetyCopies() ? "KEPT" : "-");
+
                     retval += tmp;
                     break;
                 

--- a/libs9s/s9sbackup.h
+++ b/libs9s/s9sbackup.h
@@ -67,6 +67,9 @@ class S9sBackup
         S9sString beginAsString() const;
         S9sVariant end() const;
         S9sString endAsString() const;
+        S9sVariant expires() const;
+        S9sString expiresAsString() const;
+        bool retainedBySafetyCopies() const;
         S9sString rootDir() const;
         bool isCompressed() const;
         S9sString method() const;

--- a/libs9s/s9srpcreply.cpp
+++ b/libs9s/s9srpcreply.cpp
@@ -10064,6 +10064,7 @@ S9sRpcReply::printBackupListLong()
     S9sFormat       stateFormat;
     S9sFormat       createdFormat;
     S9sFormat       ownerFormat;
+    S9sFormat       expiresFormat;
    
     // One is RPC 1.0, the other is 2.0.
     if (contains("data"))
@@ -10118,6 +10119,14 @@ S9sRpcReply::printBackupListLong()
                 
         created = backup.beginAsString();
         createdFormat.widen(created);
+
+        /*
+         * The same three answers as the %x format field: a date, "NEVER", or
+         * "-" when the controller does not report expiries at all. An older
+         * controller therefore leaves a column of dashes rather than a blank
+         * one, which would read as "no retention".
+         */
+        expiresFormat.widen(backup.expiresAsString());
     }
 
     /*
@@ -10136,6 +10145,7 @@ S9sRpcReply::printBackupListLong()
         hostNameFormat.printHeader("HOSTNAME");
         createdFormat.printHeader("CREATED");
         sizeFormat.printHeader("SIZE");
+        expiresFormat.printHeader("EXPIRES");
         printf("TITLE");
  
         printf("%s", headerColorEnd());
@@ -10252,6 +10262,12 @@ S9sRpcReply::printBackupListLong()
         
         createdFormat.printf(created);
         sizeFormat.printf(sizeString);
+
+        /*
+         * Before the title, which is last and printed without padding: a
+         * column after it would be pushed around by every title in the list.
+         */
+        expiresFormat.printf(backup.expiresAsString());
         printf("%s", STR(backup.title()));
         printf("\n");
     }

--- a/tests/ut_s9sbackup/ut_s9sbackup.cpp
+++ b/tests/ut_s9sbackup/ut_s9sbackup.cpp
@@ -115,6 +115,7 @@ UtS9sBackup::runTest(const char *testName)
     PERFORM_TEST(testCreate,          retval);
     PERFORM_TEST(testSetProperties,   retval);
     PERFORM_TEST(testAssign,          retval);
+    PERFORM_TEST(testExpiry,          retval);
 
     return retval;
 }
@@ -182,6 +183,57 @@ UtS9sBackup::testSetProperties()
 
     theString = theBackup.toString(0, 0, false, "%I %H");
     S9S_COMPARE(theString, "2 192.168.1.134");
+
+    return true;
+}
+
+/**
+ * The three answers the controller can give about when a backup expires, and
+ * the two format fields that print them.
+ *
+ * They are three because a blank column would read as "no retention" for all of
+ * them: an empty string is the controller saying the backup is never deleted, an
+ * absent field is a controller that does not report expiries at all, and a date
+ * is a date. The fixture has no `expires` at all, which is the older-controller
+ * case, so it doubles as the starting point here.
+ */
+bool
+UtS9sBackup::testExpiry()
+{
+    S9sVariantMap theMap;
+    S9sBackup     theBackup;
+
+    S9S_VERIFY(theMap.parse(backupJson1));
+
+    theBackup = theMap;
+    S9S_COMPARE(theBackup.expiresAsString(), "-");
+    S9S_COMPARE(theBackup.toString(0, 0, false, "%x"), "-");
+    S9S_VERIFY(!theBackup.retainedBySafetyCopies());
+    S9S_COMPARE(theBackup.toString(0, 0, false, "%X"), "-");
+
+    theMap["expires"] = "";
+    theBackup = theMap;
+    S9S_COMPARE(theBackup.expiresAsString(), "NEVER");
+    S9S_COMPARE(theBackup.toString(0, 0, false, "%x"), "NEVER");
+
+    /*
+     * The formatted date itself depends on the time zone and on
+     * --date-format, as the other tests in this file note, so this only pins
+     * that a real date is neither of the two words above.
+     */
+    theMap["expires"] = "2035-06-09T09:15:19.000Z";
+    theBackup = theMap;
+    S9S_VERIFY(theBackup.expiresAsString() != "-");
+    S9S_VERIFY(theBackup.expiresAsString() != "NEVER");
+
+    theMap["expires"] = "not a date";
+    theBackup = theMap;
+    S9S_COMPARE(theBackup.expiresAsString(), "-");
+
+    theMap["retained_by_safety_copies"] = true;
+    theBackup = theMap;
+    S9S_VERIFY(theBackup.retainedBySafetyCopies());
+    S9S_COMPARE(theBackup.toString(0, 0, false, "%X"), "KEPT");
 
     return true;
 }

--- a/tests/ut_s9sbackup/ut_s9sbackup.h
+++ b/tests/ut_s9sbackup/ut_s9sbackup.h
@@ -30,5 +30,6 @@ class UtS9sBackup : public S9sUnitTest
         bool testCreate();
         bool testSetProperties();
         bool testAssign();
+        bool testExpiry();
 };
 


### PR DESCRIPTION
## What

`s9s backup --list` can now show **when a backup will be deleted**, and whether the controller is keeping an expired one on purpose.

Jira: [CLUS-8329](https://severalnines.atlassian.net/browse/CLUS-8329)

This is the `s9s-tools` half of the controller change in [clustercontrol-enterprise#3541](https://github.com/severalnines/clustercontrol-enterprise/pull/3541) — the parallel class hierarchy the repo's own notes say an RPC contract change usually needs. cmon started reporting the expiry it computes; until now the CLI was the one client that could not answer the question the field was added for.

## No change to the request

`S9sRpcClient::getBackups()` asks without a `backup_record_version`, which is the **version 1** reply — flat, no nested `metadata`. The controller writes both fields at the top level in that format, so `S9sBackup` reads them the way it already reads `created`. Nothing about the request or the reply handling changes.

## Two new `--backup-format` fields

| Field | Prints |
| --- | --- |
| `%x` | when the controller will delete the backup |
| `%X` | `KEPT` when it is past its retention and being kept to honour `backup_n_safety_copies`, `-` otherwise |

```
s9s backup --list --long --backup-format="%I %10.10M %x %X\n"
```

**`%x` distinguishes three answers instead of leaving the column blank**, because only the controller can tell them apart:

| What arrives | Printed |
| --- | --- |
| no `expires` field — a controller older than it | `-` |
| empty string | `NEVER` |
| a date | the date, per `--date-format` |
| something unparseable | `-` |

A blank for all three would read as "no retention" for a backup that has one. A date in the past is not a bug either: it means the backup became eligible for deletion and the sweep has not run yet — or that it is being kept, which is what `%X` is for.

## An EXPIRES column in `--list --long`

```
ID PI CID V I STATE     OWNER    HOSTNAME      CREATED             SIZE  EXPIRES             TITLE
```

Same three answers as `%x`. It goes **before TITLE** because TITLE is last and printed without padding, so a column after it would be pushed around by every title in the list.

**This changes the default output**: a script parsing the long listing by column position now sees one more field before the title. Called out because it is the one breaking-ish part of this PR — the alternative was leaving the expiry reachable only through a format string, which for the column the whole feature exists for amounts to hiding it.

## What is deliberately not here

- **`retention_checked`** — when the hold was last decided — is in the reply and reachable through `--print-json`, but has no format field of its own. It only qualifies a `KEPT`, and the CLI surface did not seem worth widening for it.
- **The hold in the long listing.** `%X` carries it; the column says *when*. A backup kept past its retention shows the date it passed, which is the date the controller acted on.

## Testing

- Builds clean (`./autogen.sh && make -j6`), all `ut_*` binaries included.
- `ut_s9sbackup`: `testSetProperties` 22 checks, `testAssign` 24, and a new `testExpiry` with 12 — the three expiry answers, both format fields, and the hold. The formatted date itself is not asserted, for the same reason the existing tests skip it: it depends on the time zone and on `--date-format`. The test pins that a real date is neither `-` nor `NEVER`.
- The functional tests (`tests/ft_*.sh`) need a running controller and were not run.
- `doc/s9s-backup.1` documents both fields in the `--backup-format` field list.


[CLUS-8329]: https://severalnines.atlassian.net/browse/CLUS-8329?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ