### PR TITLE
CLUS-8389: remove 'pool-controllers --import-db' CLI support

### DIFF
--- a/libs9s/s9sbusinesslogic.cpp
+++ b/libs9s/s9sbusinesslogic.cpp
@@ -1516,12 +1516,6 @@ S9sBusinessLogic::execute()
             S9sRpcReply reply = client.reply();
             maybeJobRegistered(client, clusterId, success);
         }
-        else if (options->isImportDb())
-        {
-            success = client.importCmonDbInstance(options);
-            S9sRpcReply reply = client.reply();
-            maybeJobRegistered(client, clusterId, success);
-        }
         else if (options->isDeleteDb())
         {
             success = client.deleteCmonDbInstance(options);

--- a/libs9s/s9soptions.cpp
+++ b/libs9s/s9soptions.cpp
@@ -540,7 +540,6 @@ enum S9sOptionType
 
     OptionAddController,
     OptionAddDb,
-    OptionImportDb,
     OptionDeleteDb,
     OptionListDb,
     OptionControllersList,
@@ -5657,17 +5656,6 @@ S9sOptions::isAddDb() const
 }
 
 /**
- * \returns true if the "import-db" function is requested by providing the
- * --import-db command line option (imports an existing, standalone cmon DB
- * instance into the pool via the importCmonDbInstance job).
- */
-bool
-S9sOptions::isImportDb() const
-{
-    return getBool("import_db");
-}
-
-/**
  * \returns true if the "delete-db" function is requested by providing the
  * --delete-db command line option (removes a cmon DB instance from the
  * pool's cmon DB HA InnoDB Cluster via the deleteCmonDbInstance job).
@@ -5682,7 +5670,7 @@ S9sOptions::isDeleteDb() const
  * \returns true if the "list-db" function is requested by providing the
  * --list-db command line option (lists the pool's cmon DB HA InnoDB
  * Cluster nodes via the read-only getCmonDbClusterNodes RPC call - not a
- * job, unlike --add-db/--import-db/--delete-db).
+ * job, unlike --add-db/--delete-db).
  */
 bool
 S9sOptions::isListDb() const
@@ -9095,8 +9083,6 @@ S9sOptions::printHelpControllers()
 "  --add-controller           To create a new controller instance on specified host.\n"
 "  --add-db                   To join a host into the pool's cmon DB HA InnoDB Cluster\n"
 "                             as a SECONDARY (requires --nodes with exactly one node).\n"
-"  --import-db                To import an existing, standalone cmon DB instance into\n"
-"                             the pool (requires --nodes with exactly one node).\n"
 "  --delete-db                To remove a cmon DB instance from the pool's cmon DB HA\n"
 "                             InnoDB Cluster (requires --nodes with exactly one node).\n"
 "  --assignment               To retrieve the controller assigned to specific cluster (requires --cluster-id).\n"
@@ -20027,7 +20013,6 @@ S9sOptions::readOptionsControllers(
                     {"print-deployment-info", no_argument, 0,  OptionPrintDeploymentInfo},
                     {"add-controller",   no_argument, 0,       OptionAddController},
                     {"add-db",           no_argument, 0,       OptionAddDb},
-                    {"import-db",        no_argument, 0,       OptionImportDb},
                     {"delete-db",        no_argument, 0,       OptionDeleteDb},
                     {"list-db",          no_argument, 0,       OptionListDb},
                     {"assignment",       no_argument, 0,       OptionAssignedController},
@@ -20262,11 +20247,6 @@ S9sOptions::readOptionsControllers(
                 m_options["add_db"] = true;
                 break;
 
-            case OptionImportDb:
-                // --import-db
-                m_options["import_db"] = true;
-                break;
-
             case OptionDeleteDb:
                 // --delete-db
                 m_options["delete_db"] = true;
@@ -20419,9 +20399,6 @@ S9sOptions::checkOptionsControllers()
         countOptions++;
 
     if (isAddDb())
-        countOptions++;
-
-    if (isImportDb())
         countOptions++;
 
     if (isDeleteDb())

--- a/libs9s/s9soptions.h
+++ b/libs9s/s9soptions.h
@@ -552,7 +552,6 @@ class S9sOptions
         bool isUnsetPoolModeRequested() const;
         bool isAddController() const;
         bool isAddDb() const;
-        bool isImportDb() const;
         bool isDeleteDb() const;
         bool isListDb() const;
         bool isStartController() const;

--- a/libs9s/s9srpcclient.cpp
+++ b/libs9s/s9srpcclient.cpp
@@ -11679,7 +11679,7 @@ S9sRpcClient::assignedController(S9sOptions *options)
 /**
  * @brief lists the pool's cmon DB HA InnoDB Cluster nodes
  * (getCmonDbClusterNodes - a read-only query, unlike the job-creating
- * addCmonDbInstance/ImportCmonDbInstance/DeleteCmonDbInstance calls).
+ * addCmonDbInstance/DeleteCmonDbInstance calls).
  *
  * Mirrors listControllers()'s own wiring: same "/v2/poolcontrollers/"
  * endpoint, same fire-and-render pattern (no job to wait on).
@@ -11816,59 +11816,6 @@ S9sRpcClient::addNewCmonDbInstance(S9sOptions *options)
     // The job instance describing how the job will be executed.
     job["job_spec"] = jobSpec;
     job["title"]    = "Add DB Instance to Pool";
-
-    request["operation"] = "createJobInstance";
-    request["job"]       = job;
-
-    return executeRequest(uri, request);
-}
-
-/**
- * @brief import an existing, standalone cmon DB instance into the pool
- * (CmdImportCmonDbInstance / the ImportCmonDbInstance job).
- *
- * Same job_data shape as addNewCmonDbInstance() - SSH credentials, when
- * given via --os-user/--os-key-file/--os-password, flow through
- * composeJobData() the same way.
- */
-bool
-S9sRpcClient::importCmonDbInstance(S9sOptions *options)
-{
-    const S9sString uri = "/v2/jobs/";
-    S9sVariantMap   request;
-
-    S9sVariantList hosts = options->nodes();
-
-    S9sVariantMap job     = composeJob();
-    S9sVariantMap jobData = composeJobData();
-    S9sVariantMap jobSpec;
-
-    if (hosts.size() == 1)
-    {
-        jobData["server_address"] = hosts[0].toNode().hostName();
-        // S9sNode::port() defaults to 0 when no ':port' was given on
-        // --nodes, unlike the ImportCmonDbInstance job's own 3306 default.
-        int port = hosts[0].toNode().port();
-        jobData["port"] = port > 0 ? port : 3306;
-    }
-    else
-    {
-        PRINT_ERROR(
-                "Exactly one node must specified for "
-                "importCmonDbInstance operation.");
-        options->setExitStatus(S9sOptions::BadOptions);
-        return false;
-    }
-
-    jobData["force"] = options->getBool("force");
-
-    // The jobspec describing the command.
-    jobSpec["command"]  = "ImportCmonDbInstance";
-    jobSpec["job_data"] = jobData;
-
-    // The job instance describing how the job will be executed.
-    job["job_spec"] = jobSpec;
-    job["title"]    = "Import DB Instance to Pool";
 
     request["operation"] = "createJobInstance";
     request["job"]       = job;

--- a/libs9s/s9srpcclient.h
+++ b/libs9s/s9srpcclient.h
@@ -371,7 +371,6 @@ class S9sRpcClient
         bool setPoolMode(S9sOptions *options);
         bool addNewController(S9sOptions *options);
         bool addNewCmonDbInstance(S9sOptions *options);
-        bool importCmonDbInstance(S9sOptions *options);
         bool deleteCmonDbInstance(S9sOptions *options);
         bool startController(S9sOptions *options);
         bool stopController(S9sOptions *options);

--- a/libs9s/s9srpcreply.cpp
+++ b/libs9s/s9srpcreply.cpp
@@ -2005,14 +2005,14 @@ S9sRpcReply::printCmonDbClusterNodes()
  * Lists the pool's cmon DB HA InnoDB Cluster nodes (read-only
  * getCmonDbClusterNodes call, "pool-controllers --list-db").
  *
- * The reply shape is intentionally minimal (CmonInnoDbClusterNodeHost
+ * The reply shape is intentionally minimal (CmonPoolModeDbClusterNodeHost
  * records: hostname/port only - no role/status, since nothing monitors
  * live member state for these records):
  *
  * \code{.js}
  * {
  *   "cmon_db_cluster_nodes": [
- *     {"class_name": "CmonInnoDbClusterNodeHost", "cluster_id": 0,
+ *     {"class_name": "CmonPoolModeDbClusterNodeHost", "cluster_id": 0,
  *      "hostname": "10.0.1.42", "port": 3306},
  *     ...
  *   ],

--- a/tests/ut_s9soptions/ut_s9soptions.cpp
+++ b/tests/ut_s9soptions/ut_s9soptions.cpp
@@ -64,7 +64,6 @@ UtS9sOptions::runTest(const char *testName)
     PERFORM_TEST(testConfigureWalOptions, retval);
     PERFORM_TEST(testAddController, retval);
     PERFORM_TEST(testAddDb, retval);
-    PERFORM_TEST(testImportDb, retval);
     PERFORM_TEST(testDeleteDb, retval);
     PERFORM_TEST(testListDb, retval);
     PERFORM_TEST(testVirtualRouterId, retval);
@@ -896,49 +895,6 @@ UtS9sOptions::testAddDb()
 }
 
 bool
-UtS9sOptions::testImportDb()
-{
-    S9sOptions *options = S9sOptions::instance();
-
-    const char *argv1[] = { "/bin/s9s",
-                            "pool-controllers",
-                            "--import-db",
-                            "--nodes=10.16.186.1:3306",
-                            nullptr };
-    int         argc1   = sizeof(argv1) / sizeof(char *) - 1;
-
-    S9sOptions::uninit();
-    options = S9sOptions::instance();
-    S9S_VERIFY(options->readOptions(&argc1, (char **)argv1));
-    S9S_VERIFY(options->isImportDb());
-    S9S_COMPARE(options->nodes().size(), 1);
-    S9S_COMPARE(options->nodes()[0].toNode().hostName(), ("10.16.186.1"));
-    S9S_COMPARE(options->nodes()[0].toNode().port(), 3306);
-    S9S_VERIFY(!options->getBool("force"));
-
-    S9sOptions::uninit();
-
-    // --force must also be accepted and readable via the generic
-    // getBool("force") accessor, the same way importCmonDbInstance() reads
-    // it when building the job's job_data.
-    const char *argv2[] = { "/bin/s9s",
-                            "pool-controllers",
-                            "--import-db",
-                            "--nodes=10.16.186.1:3306",
-                            "--force",
-                            nullptr };
-    int         argc2   = sizeof(argv2) / sizeof(char *) - 1;
-
-    options = S9sOptions::instance();
-    S9S_VERIFY(options->readOptions(&argc2, (char **)argv2));
-    S9S_VERIFY(options->isImportDb());
-    S9S_VERIFY(options->getBool("force"));
-
-    S9sOptions::uninit();
-    return true;
-}
-
-bool
 UtS9sOptions::testDeleteDb()
 {
     S9sOptions *options = S9sOptions::instance();
@@ -987,7 +943,7 @@ UtS9sOptions::testListDb()
     S9sOptions *options = S9sOptions::instance();
 
     // --list-db is a read-only query: no --nodes required, unlike
-    // --add-db/--import-db/--delete-db.
+    // --add-db/--delete-db.
     const char *argv1[] = { "/bin/s9s",
                             "pool-controllers",
                             "--list-db",

--- a/tests/ut_s9soptions/ut_s9soptions.h
+++ b/tests/ut_s9soptions/ut_s9soptions.h
@@ -47,7 +47,6 @@ class UtS9sOptions : public S9sUnitTest
         bool testConfigureWalOptions();
         bool testAddController();
         bool testAddDb();
-        bool testImportDb();
         bool testDeleteDb();
         bool testListDb();
         bool testVirtualRouterId();

--- a/tests/ut_s9srpcclient/ut_s9srpcclient.cpp
+++ b/tests/ut_s9srpcclient/ut_s9srpcclient.cpp
@@ -174,7 +174,6 @@ UtS9sRpcClient::runTest(
     PERFORM_TEST(testConfigureWal, retval);
     PERFORM_TEST(testAddController, retval);
     PERFORM_TEST(testAddDb, retval);
-    PERFORM_TEST(testImportDb, retval);
     PERFORM_TEST(testDeleteDb, retval);
     PERFORM_TEST(testListDb, retval);
 
@@ -3012,59 +3011,6 @@ UtS9sRpcClient::testAddDb()
     options->m_options["force"] = true;
 
     S9S_VERIFY(client.addNewCmonDbInstance(options));
-    payload = client.lastPayload();
-
-    jobData = payload["job"]["job_spec"]["job_data"].toVariantMap();
-    S9S_COMPARE(jobData["server_address"], "10.0.1.87");
-    S9S_COMPARE(jobData["port"], 3306);
-    S9S_VERIFY(jobData["force"].toBoolean());
-
-    return true;
-}
-
-/**
- * Testing importCmonDbInstance() (the "pool-controllers --import-db" job -
- * CmdImportCmonDbInstance) request shape: job_spec.command, and job_data's
- * server_address/port/force fields.
- */
-bool
-UtS9sRpcClient::testImportDb()
-{
-    S9sOptions         *options = S9sOptions::instance();
-    S9sRpcClientTester  client;
-    S9sVariantMap       payload;
-    S9sVariantMap       jobData;
-
-    // Explicit port, force omitted (must default to false).
-    S9sOptions::uninit();
-    options = S9sOptions::instance();
-    options->setNodes("10.0.1.87:3307");
-
-    S9S_VERIFY(client.importCmonDbInstance(options));
-    payload = client.lastPayload();
-
-    if (isVerbose())
-        printDebug(payload);
-
-    S9S_COMPARE(payload["operation"], "createJobInstance");
-    S9S_COMPARE(
-            payload.valueByPath("/job/job_spec/command").toString(),
-            "ImportCmonDbInstance");
-
-    jobData = payload["job"]["job_spec"]["job_data"].toVariantMap();
-    S9S_COMPARE(jobData["server_address"], "10.0.1.87");
-    S9S_COMPARE(jobData["port"], 3307);
-    S9S_VERIFY(!jobData["force"].toBoolean());
-
-    // No port on --nodes -> must default to 3306 (S9sNode::port() itself
-    // defaults to 0, not 3306, so importCmonDbInstance() must apply the
-    // fallback itself). --force must also come through.
-    S9sOptions::uninit();
-    options = S9sOptions::instance();
-    options->setNodes("10.0.1.87");
-    options->m_options["force"] = true;
-
-    S9S_VERIFY(client.importCmonDbInstance(options));
     payload = client.lastPayload();
 
     jobData = payload["job"]["job_spec"]["job_data"].toVariantMap();

--- a/tests/ut_s9srpcclient/ut_s9srpcclient.h
+++ b/tests/ut_s9srpcclient/ut_s9srpcclient.h
@@ -114,7 +114,6 @@ class UtS9sRpcClient : public S9sUnitTest
         bool testConfigureWal();
         bool testAddController();
         bool testAddDb();
-        bool testImportDb();
         bool testDeleteDb();
         bool testListDb();
 };


### PR DESCRIPTION
## Summary
- Removes `--import-db`/`ImportCmonDbInstance` CLI support, following the removal of `CmdImportCmonDbInstance` from clustercontrol-enterprise (PR #3514) - pool growth is add-only now (`--add-db`), there is no non-destructive import path to expose from the CLI anymore.
- Renames the two `CmonInnoDbClusterNodeHost` doc-comment references to `CmonPoolModeDbClusterNodeHost`, matching the class rename on the clustercontrol-enterprise side (avoids implying cmon supports InnoDB Cluster as a first-class managed cluster type).

## Test plan
- [x] Full build succeeds (`./autogen.sh && make -j`)
- [x] `ut_s9soptions` passes in full
- [x] `ut_s9srpcclient` passes in full

Related: CLUS-8389, PR #229 (originally added `--add-db`/`--import-db`/`--delete-db`/`--list-db`), clustercontrol-enterprise PR #3514.

🤖 Generated with [Claude Code](https://claude.com/claude-code)