### PR TITLE
CLUS-8578: Job to setup OpenBao instance

### DIFF
--- a/doc/s9s-pool-controllers.1
+++ b/doc/s9s-pool-controllers.1
@@ -111,6 +111,40 @@ s9s pool-controllers --update-cmon --controller-id=2
 .fi
 
 .TP
+.B --add-openbao
+Installs and bootstraps an OpenBao instance on the host named by '--nodes' (exactly
+one host is required). Requires super admin privileges.
+
+The root token and the unseal keys are written to '/etc/openbao/init.json'
+on the target host.
+.nf
+s9s pool-controllers --add-openbao --nodes=10.16.186.189 --log
+.fi
+
+To install a specific version on a non-default port, inside a namespace. The
+version comes from \fB--provider-version\fP and the listener port from the node
+specification, the same way \fB--add-controller\fP takes them:
+.nf
+s9s pool-controllers --add-openbao --nodes=10.16.186.189:8300 \\
+    --provider-version=2.5.4 --openbao-mount=clustercontrol \\
+    --openbao-namespace=tenant1 --log
+.fi
+
+The package by default is downloaded from the public OpenBao release page and
+verified against the checksums that release publishes.
+
+\fB--openbao-package-path\fP installs a package already staged on the
+host, and \fB--use-internal-repos\fP installs it by name from the repositories
+the host has configured.
+
+Installing on a host with no route to the internet, from a package staged there
+beforehand:
+.nf
+s9s pool-controllers --add-openbao --nodes=10.16.186.189 \\
+    --openbao-package-path=/var/tmp/openbao_2.5.4_linux_amd64.deb --log
+.fi
+
+.TP
 .BI \-\^\-set-max-clusters-capacity=N
 Sets how many clusters the controller receiving the request can own. Sentinels:
 .B -2
@@ -158,6 +192,44 @@ By default only controllers with dynamic status ('stopped', 'starting', 'active'
 .TP
 .BI \-\^\-provider-version=VERSION
 Controller version to be installed.
+
+.TP
+.BI \-\^\-openbao-mount=MOUNT
+Used with \fB--add-openbao\fP: the path of the KV v2 secrets engine the job
+creates. Defaults to 'clustercontrol' on the controller side.
+
+.TP
+.BI \-\^\-openbao-namespace=NAME
+Used with \fB--add-openbao\fP: an OpenBao namespace to create and use. No
+namespace is created when the option is omitted. Namespaces are an OpenBao
+feature; on HashiCorp Vault they are Enterprise-only.
+
+.TP
+.BI \-\^\-openbao-package=SPEC
+Used with \fB--add-openbao\fP and \fB--use-internal-repos\fP: the exact package
+spec to install, so a version can be pinned with the package manager's own
+syntax (e.g. 'openbao=2.5.4-1' for apt, 'openbao-2.5.4' for yum). The default
+is plain 'openbao'.
+
+.TP
+.BI \-\^\-openbao-package-path=PATH
+Used with \fB--add-openbao\fP: the absolute path of a package file already
+staged on the target host. It is installed as it is - nothing is downloaded and
+no checksum is verified, because whoever staged the file vouched for it. This is
+the option for a host with no outbound internet access. Takes precedence over
+\fB--use-internal-repos\fP.
+
+.TP
+.B \-\^\-openbao-force-reinit
+Used with \fB--add-openbao\fP:
+.B destroys the existing OpenBao instance on the host.
+The data directory is renamed rather than deleted, but the new instance is
+initialised from scratch with new unseal keys, so every secret the old one held
+becomes unreachable. Without this option the job refuses to restart an
+initialised instance whose '/etc/openbao/init.json' is missing, because it could
+not be unsealed again afterwards; this option is the way out of that state when
+the keys are genuinely lost and the instance holds nothing of value. Use it on a
+scratch instance only.
 
 .TP
 .B \-\^\-uninstall

--- a/libs9s/s9sbusinesslogic.cpp
+++ b/libs9s/s9sbusinesslogic.cpp
@@ -1564,6 +1564,12 @@ S9sBusinessLogic::execute()
             S9sRpcReply reply = client.reply();
             maybeJobRegistered(client, clusterId, success);
         }
+        else if (options->isAddOpenBao())
+        {
+            success = client.installOpenBao(options);
+            S9sRpcReply reply = client.reply();
+            maybeJobRegistered(client, clusterId, success);
+        }
         else if (options->isSetMaxClustersCapacityRequested())
         {
             client.setMaxClustersCapacity(options);

--- a/libs9s/s9soptions.cpp
+++ b/libs9s/s9soptions.cpp
@@ -556,6 +556,12 @@ enum S9sOptionType
     OptionRemoveController,
     OptionUpdateCmon,
     OptionSetMaxClustersCapacity,
+    OptionAddOpenBao,
+    OptionOpenBaoMount,
+    OptionOpenBaoNamespace,
+    OptionOpenBaoPackagePath,
+    OptionOpenBaoPackage,
+    OptionOpenBaoForceReinit,
 
     OptionExtensions,
     OptionPgHbaRules,
@@ -5741,6 +5747,83 @@ S9sOptions::getMaxClustersCapacity() const
 }
 
 /**
+ * \returns true if the "installOpenBao" job is requested by providing the
+ *   --add-openbao command line option on the "pool-controllers" subcommand.
+ */
+bool
+S9sOptions::isAddOpenBao() const
+{
+    return getBool("add_openbao");
+}
+
+/**
+ * \returns true if any of the --openbao-* command line options was provided.
+ *
+ * Used by the option check to reject the parameters of the OpenBao installation
+ * when no OpenBao installation was requested at all.
+ */
+bool
+S9sOptions::hasOpenBaoOption() const
+{
+    return m_options.contains("openbao_mount")
+        || m_options.contains("openbao_namespace")
+        || m_options.contains("openbao_package_path")
+        || m_options.contains("openbao_package")
+        || m_options.contains("openbao_force_reinit");
+}
+
+/**
+ * \returns The value of the --openbao-mount command line option or the empty
+ *   string if no such an option is used.
+ */
+S9sString
+S9sOptions::openBaoMount() const
+{
+    return getString("openbao_mount");
+}
+
+/**
+ * \returns The value of the --openbao-namespace command line option or the empty
+ *   string if no such an option is used.
+ */
+S9sString
+S9sOptions::openBaoNamespace() const
+{
+    return getString("openbao_namespace");
+}
+
+/**
+ * \returns The value of the --openbao-package-path command line option or the
+ *   empty string if no such an option is used.
+ */
+S9sString
+S9sOptions::openBaoPackagePath() const
+{
+    return getString("openbao_package_path");
+}
+
+
+
+/**
+ * \returns The value of the --openbao-package command line option or the empty
+ *   string if no such an option is used.
+ */
+S9sString
+S9sOptions::openBaoPackage() const
+{
+    return getString("openbao_package");
+}
+
+/**
+ * \returns true if the --openbao-force-reinit command line option was provided.
+ */
+bool
+S9sOptions::openBaoForceReinit() const
+{
+    return getBool("openbao_force_reinit");
+}
+
+/**
  * \returns true if the --add-publication command line option was provided.
  */
 bool
@@ -9104,12 +9187,26 @@ S9sOptions::printHelpControllers()
 "  --stop                     To stop a controller (requires --controller-id).\n"
 "  --remove-controller        To remove a controller (requires --controller-id).\n"
 "  --update-cmon              To update cmon package on a controller (requires --controller-id).\n"
+"  --add-openbao              To install an OpenBao instance on the host given by --nodes.\n"
 "  --controller-id            To specify the controller ID to retrieve info from.\n"
 "  --cluster-id               To specify the cluster ID to retrieve info from.\n"
 "  --comment                  To specify the command associated to credential to create.\n"
 "  --nodes=NODELIST           The nodes for the controller operation.\n"
 "  --use-internal-repos       Use local repos when installing software.\n"
 "  --uninstall                Uninstall software when removing controller.\n"
+"  --openbao-mount=MOUNT      The KV v2 mount to create (default: clustercontrol).\n"
+"  --openbao-namespace=NAME   The OpenBao namespace to create (default: none).\n"
+"  --openbao-package-path=PATH\n"
+"                             Install a package already staged on the target host\n"
+"                             instead of downloading one.\n"
+"  --openbao-force-reinit     Discard any existing OpenBao storage on the host and\n"
+"                             initialise a fresh instance. The previous data\n"
+"                             directory is renamed, not deleted, but its secrets\n"
+"                             become unreachable. Use only on a scratch instance.\n"
+"  --no-install               Do not install the openbao package; it must already\n"
+"                             be present on the host.\n"
+"  --openbao-package=SPEC     With --use-internal-repos, the exact package spec to\n"
+"                             install (e.g. openbao=2.5.4-1). Default: openbao.\n"
 "  --set-max-clusters-capacity=N  Set how many clusters this controller can own. Sentinels:\n"
 "                             -2 = auto (RAM-based), -1 = unlimited, 0 = inactive (own no\n"
 "                             clusters: abandon all, acquire none), >0 = explicit cap. Takes\n"
@@ -20038,6 +20135,7 @@ S9sOptions::readOptionsControllers(
                     {"remove-controller", no_argument, 0,      OptionRemoveController},
                     {"update-cmon",      no_argument, 0,       OptionUpdateCmon},
                     {"set-max-clusters-capacity", required_argument, 0, OptionSetMaxClustersCapacity},
+                    {"add-openbao",      no_argument, 0,       OptionAddOpenBao},
                     {"force",                    no_argument,       0, OptionForce},
                     // Arguments when creating or updating controllers
                     {"controller-id",    required_argument, 0, OptionControllerId},
@@ -20047,6 +20145,13 @@ S9sOptions::readOptionsControllers(
                     {"granted-network-mask", required_argument, 0, OptionGrantedNetworkMask},
                     {"use-internal-repos", no_argument,     0, OptionUseInternalRepos },
                     {"uninstall",        no_argument,       0, OptionUninstall},
+                    // Arguments when installing an OpenBao instance
+                    {"openbao-mount",    required_argument, 0, OptionOpenBaoMount},
+                    {"openbao-namespace", required_argument, 0, OptionOpenBaoNamespace},
+                    {"openbao-package-path", required_argument, 0, OptionOpenBaoPackagePath},
+                    {"openbao-package",  required_argument, 0, OptionOpenBaoPackage},
+                    {"openbao-force-reinit", no_argument, 0, OptionOpenBaoForceReinit},
+                    { "no-install",      no_argument,       0, OptionNoInstall },
                     
                     // Job Related Options
                     {"log",              no_argument,       0, 'G'},
@@ -20296,6 +20401,11 @@ S9sOptions::readOptionsControllers(
                 m_options["update_cmon"] = true;
                 break;
 
+            case OptionAddOpenBao:
+                // --add-openbao
+                m_options["add_openbao"] = true;
+                break;
+
             case OptionSetMaxClustersCapacity:
                 // --set-max-clusters-capacity=N
                 if (optarg)
@@ -20354,6 +20464,36 @@ S9sOptions::readOptionsControllers(
             case OptionUninstall:
                 // --uninstall
                 m_options["uninstall"] = true;
+                break;
+
+            case OptionOpenBaoMount:
+                // --openbao-mount=MOUNT
+                m_options["openbao_mount"] = optarg;
+                break;
+
+            case OptionOpenBaoNamespace:
+                // --openbao-namespace=NAMESPACE
+                m_options["openbao_namespace"] = optarg;
+                break;
+
+                // --openbao-package-path=PATH
+            case OptionOpenBaoPackagePath:
+                m_options["openbao_package_path"] = optarg;
+                break;
+
+                // --openbao-package=SPEC
+            case OptionOpenBaoPackage:
+                m_options["openbao_package"] = optarg;
+                break;
+
+                // --openbao-force-reinit
+            case OptionOpenBaoForceReinit:
+                m_options["openbao_force_reinit"] = true;
+                break;
+
+            case OptionNoInstall:
+                // --no-install
+                m_options["no_install"] = true;
                 break;
 
             /*
@@ -20445,6 +20585,9 @@ S9sOptions::checkOptionsControllers()
     if (isSetMaxClustersCapacityRequested())
         countOptions++;
 
+    if (isAddOpenBao())
+        countOptions++;
+
     if (countOptions == 0)
     {
         m_errorMessage = "One of the main options is mandatory.";
@@ -20487,6 +20630,24 @@ S9sOptions::checkOptionsControllers()
             m_exitStatus = BadOptions;
             return false;
         }
+    }
+
+    // Validate the OpenBao options only when relevant
+    if (hasOpenBaoOption())
+    {
+        if (!isAddOpenBao())
+        {
+            m_errorMessage = "The --openbao-* options can only be used with --add-openbao.";
+            m_exitStatus = BadOptions;
+            return false;
+        }
+    }
+
+    if (isAddOpenBao() && nodes().size() != 1u)
+    {
+        m_errorMessage = "The --nodes option must specify exactly one host for --add-openbao.";
+        m_exitStatus = BadOptions;
+        return false;
     }
 
     return true;

--- a/libs9s/s9soptions.h
+++ b/libs9s/s9soptions.h
@@ -561,6 +561,13 @@ class S9sOptions
         bool isUpdateCmon() const;
         bool isSetMaxClustersCapacityRequested() const;
         int  getMaxClustersCapacity() const;
+        bool isAddOpenBao() const;
+        bool hasOpenBaoOption() const;
+        S9sString openBaoMount() const;
+        S9sString openBaoNamespace() const;
+        S9sString openBaoPackagePath() const;
+        S9sString openBaoPackage() const;
+        bool openBaoForceReinit() const;
 
         bool isGenerateKeyRequested() const;
         S9sString group() const;

--- a/libs9s/s9srpcclient.cpp
+++ b/libs9s/s9srpcclient.cpp
@@ -12060,6 +12060,86 @@ S9sRpcClient::updateCmon(S9sOptions *options)
 }
 
 /**
+ * \returns true if the request was successfully sent
+ *
+ * Creates the job that installs an OpenBao instance on the host given by the
+ * --nodes command line option. The job only produces the instance: it does not
+ * point this controller at it, so nothing here writes the vaultkv_* settings.
+ *
+ * Every --openbao-* parameter is optional and is only put into the job_data when
+ * it was actually given on the command line - an absent key means the controller
+ * applies its own default. The root token and the unseal keys are left on the
+ * target host by the job, so there is nothing sensitive to send or to receive
+ * here.
+ */
+bool
+S9sRpcClient::installOpenBao(S9sOptions *options)
+{
+    const S9sString uri = "/v2/jobs/";
+    S9sVariantMap   request;
+
+    S9sVariantList  hosts = options->nodes();
+
+    S9sVariantMap   job     = composeJob();
+    S9sVariantMap   jobData = composeJobData();
+    S9sVariantMap   jobSpec;
+
+    if (hosts.size() == 1)
+    {
+        jobData["server_address"] = hosts[0].toNode().hostName();
+
+        const int port = hosts[0].toNode().port();
+        if (port > 0)
+            jobData["port"] = port;
+    }
+    else
+    {
+        PRINT_ERROR(
+                "Exactly one node must specified for "
+                "installOpenBao operation.");
+        options->setExitStatus(S9sOptions::BadOptions);
+        return false;
+    }
+
+    if (!options->providerVersion().empty())
+        jobData["version"] = options->providerVersion();
+
+    if (!options->openBaoMount().empty())
+        jobData["openbao_mount"] = options->openBaoMount();
+
+    if (!options->openBaoNamespace().empty())
+        jobData["openbao_namespace"] = options->openBaoNamespace();
+
+    if (!options->openBaoPackagePath().empty())
+        jobData["openbao_package_path"] = options->openBaoPackagePath();
+
+    if (!options->openBaoPackage().empty())
+        jobData["openbao_package"] = options->openBaoPackage();
+
+    // install_software defaults to true controller-side; only --no-install needs
+    // to be transmitted.
+    if (options->noInstall())
+        jobData["install_software"] = false;
+
+    if (options->openBaoForceReinit())
+        jobData["openbao_force_reinit"] = true;
+
+    // The jobspec describing the command. The controller registers this job
+    // under the SETUP_OPENBAO action and uppercases what it receives.
+    jobSpec["command"]  = "setup_openbao";
+    jobSpec["job_data"] = jobData;
+
+    // The job instance describing how the job will be executed.
+    job["job_spec"] = jobSpec;
+    job["title"]    = "Setup OpenBao";
+
+    request["operation"] = "createJobInstance";
+    request["job"]       = job;
+
+    return executeRequest(uri, request);
+}
+
+/**
  * \returns delete watchlists stored on controller DB
  *
  */

--- a/libs9s/s9srpcclient.h
+++ b/libs9s/s9srpcclient.h
@@ -378,6 +378,7 @@ class S9sRpcClient
         bool removeController(S9sOptions *options);
         bool updateCmon(S9sOptions *options);
         bool setMaxClustersCapacity(S9sOptions *options);
+        bool installOpenBao(S9sOptions *options);
 
         /*
          * Requests related to logical replication

--- a/tests/ut_s9soptions/ut_s9soptions.cpp
+++ b/tests/ut_s9soptions/ut_s9soptions.cpp
@@ -67,6 +67,7 @@ UtS9sOptions::runTest(const char *testName)
     PERFORM_TEST(testImportDb, retval);
     PERFORM_TEST(testDeleteDb, retval);
     PERFORM_TEST(testListDb, retval);
+    PERFORM_TEST(testAddOpenBao, retval);
     PERFORM_TEST(testVirtualRouterId, retval);
     PERFORM_TEST(testRestoreClusterInfoOptions, retval);
 
@@ -998,6 +999,91 @@ UtS9sOptions::testListDb()
     options = S9sOptions::instance();
     S9S_VERIFY(options->readOptions(&argc1, (char **)argv1));
     S9S_VERIFY(options->isListDb());
+
+    S9sOptions::uninit();
+    return true;
+}
+
+/**
+ * Testing the --add-openbao option and its parameters on the pool-controllers
+ * subcommand.
+ *
+ * The version and the listener port are deliberately not openbao-specific
+ * options: they ride --provider-version and the node specification, the same way
+ * --add-controller takes them.
+ */
+bool
+UtS9sOptions::testAddOpenBao()
+{
+    S9sOptions *options;
+
+    // Every parameter given.
+    const char *argv1[] = { "/bin/s9s",
+                            "pool-controllers",
+                            "--add-openbao",
+                            "--nodes=10.16.186.1:8300",
+                            "--provider-version=2.5.4",
+                            "--openbao-mount=clustercontrol",
+                            "--openbao-namespace=tenant1",
+                            "--openbao-force-reinit",
+                            "--no-install",
+                            nullptr };
+    int         argc1   = sizeof(argv1) / sizeof(char *) - 1;
+
+    S9sOptions::uninit();
+    options = S9sOptions::instance();
+    S9S_VERIFY(options->readOptions(&argc1, (char **)argv1));
+    S9S_VERIFY(options->isAddOpenBao());
+    S9S_COMPARE(options->nodes().size(), 1);
+    S9S_COMPARE(options->nodes()[0].toNode().hostName(), "10.16.186.1");
+    S9S_COMPARE(options->nodes()[0].toNode().port(), 8300);
+    S9S_COMPARE(options->providerVersion(), "2.5.4");
+    S9S_COMPARE(options->openBaoMount(), "clustercontrol");
+    S9S_COMPARE(options->openBaoNamespace(), "tenant1");
+    S9S_VERIFY(options->openBaoForceReinit());
+    S9S_VERIFY(options->noInstall());
+
+    // No parameter given: the controller's own defaults must be used, so
+    // nothing is set here.
+    const char *argv2[] = { "/bin/s9s",
+                            "pool-controllers",
+                            "--add-openbao",
+                            "--nodes=10.16.186.1",
+                            nullptr };
+    int         argc2   = sizeof(argv2) / sizeof(char *) - 1;
+
+    S9sOptions::uninit();
+    options = S9sOptions::instance();
+    S9S_VERIFY(options->readOptions(&argc2, (char **)argv2));
+    S9S_VERIFY(options->isAddOpenBao());
+    S9S_VERIFY(!options->hasOpenBaoOption());
+    S9S_COMPARE(options->providerVersion(""), "");
+    S9S_COMPARE(options->openBaoMount(), "");
+    S9S_VERIFY(!options->openBaoForceReinit());
+    S9S_VERIFY(!options->noInstall());
+
+    // The host is mandatory.
+    const char *argv3[] = { "/bin/s9s",
+                            "pool-controllers",
+                            "--add-openbao",
+                            nullptr };
+    int         argc3   = sizeof(argv3) / sizeof(char *) - 1;
+
+    S9sOptions::uninit();
+    options = S9sOptions::instance();
+    S9S_VERIFY(!options->readOptions(&argc3, (char **)argv3));
+
+    // The parameters are meaningless without --add-openbao.
+    const char *argv4[] = { "/bin/s9s",
+                            "pool-controllers",
+                            "--list",
+                            "--openbao-mount=clustercontrol",
+                            nullptr };
+    int         argc4   = sizeof(argv4) / sizeof(char *) - 1;
+
+    S9sOptions::uninit();
+    options = S9sOptions::instance();
+    S9S_VERIFY(!options->readOptions(&argc4, (char **)argv4));
 
     S9sOptions::uninit();
     return true;

--- a/tests/ut_s9soptions/ut_s9soptions.h
+++ b/tests/ut_s9soptions/ut_s9soptions.h
@@ -50,6 +50,7 @@ class UtS9sOptions : public S9sUnitTest
         bool testImportDb();
         bool testDeleteDb();
         bool testListDb();
+        bool testAddOpenBao();
         bool testVirtualRouterId();
         bool testRestoreClusterInfoOptions();
 };

--- a/tests/ut_s9srpcclient/ut_s9srpcclient.cpp
+++ b/tests/ut_s9srpcclient/ut_s9srpcclient.cpp
@@ -177,6 +177,7 @@ UtS9sRpcClient::runTest(
     PERFORM_TEST(testImportDb, retval);
     PERFORM_TEST(testDeleteDb, retval);
     PERFORM_TEST(testListDb, retval);
+    PERFORM_TEST(testInstallOpenBao, retval);
 
     return retval;
 }
@@ -3151,6 +3152,80 @@ UtS9sRpcClient::testListDb()
         printDebug(payload);
 
     S9S_COMPARE(payload["operation"], "getcmondbclusternodes");
+
+    return true;
+}
+
+/**
+ * Testing installOpenBao() (the "pool-controllers --add-openbao" job -
+ * CmdSetupOpenBao) request shape.
+ *
+ * The version and the listener port are deliberately NOT openbao-specific
+ * options: they ride the standard --provider-version option and the node
+ * specification, exactly as the add-controller job takes them.
+ */
+bool
+UtS9sRpcClient::testInstallOpenBao()
+{
+    S9sOptions         *options = S9sOptions::instance();
+    S9sRpcClientTester  client;
+    S9sVariantMap       payload;
+
+    S9sOptions::uninit();
+    options = S9sOptions::instance();
+
+    // Port from the node spec, version from --provider-version.
+    options->setNodes("10.16.186.1:8300");
+    options->m_options["provider_version"]      = "2.5.4";
+    options->m_options["openbao_mount"]         = "clustercontrol";
+    options->m_options["openbao_namespace"]     = "tenant1";
+    options->m_options["openbao_force_reinit"]  = true;
+    options->m_options["no_install"]            = true;
+
+    S9S_VERIFY(client.installOpenBao(options));
+    payload = client.lastPayload();
+
+    if (isVerbose())
+        printDebug(payload);
+
+    S9S_COMPARE(payload["operation"], "createJobInstance");
+    // The controller registers the action as SETUP_OPENBAO and uppercases
+    // whatever it receives, so this must not be camel-cased.
+    S9S_COMPARE(
+            payload.valueByPath("/job/job_spec/command").toString(),
+            "setup_openbao");
+    S9S_COMPARE(payload.valueByPath("/job/title").toString(), "Setup OpenBao");
+
+    auto jobData = payload["job"]["job_spec"]["job_data"].toVariantMap();
+    S9S_COMPARE(jobData["server_address"], "10.16.186.1");
+    S9S_COMPARE(jobData["port"], 8300);
+    S9S_COMPARE(jobData["version"], "2.5.4");
+    S9S_COMPARE(jobData["openbao_mount"], "clustercontrol");
+    S9S_COMPARE(jobData["openbao_namespace"], "tenant1");
+    S9S_COMPARE(jobData["openbao_force_reinit"], true);
+    S9S_COMPARE(jobData["install_software"], false);
+
+    /*
+     * Without the parameters the job_data must carry no openbao_* key and no
+     * version, so that the controller applies its own defaults.
+     */
+    S9sOptions::uninit();
+    options = S9sOptions::instance();
+    options->setNodes("10.16.186.1");
+
+    S9S_VERIFY(client.installOpenBao(options));
+    payload = client.lastPayload();
+    jobData = payload["job"]["job_spec"]["job_data"].toVariantMap();
+
+    S9S_COMPARE(jobData["server_address"], "10.16.186.1");
+    // No port in the node spec: the key is omitted so the controller uses its
+    // own OpenBao default rather than being handed a 0.
+    S9S_VERIFY(!jobData.contains("port"));
+    S9S_VERIFY(!jobData.contains("version"));
+    S9S_VERIFY(!jobData.contains("openbao_mount"));
+    S9S_VERIFY(!jobData.contains("openbao_namespace"));
+    S9S_VERIFY(!jobData.contains("openbao_force_reinit"));
+    S9S_VERIFY(!jobData.contains("install_software"));
 
     return true;
 }

--- a/tests/ut_s9srpcclient/ut_s9srpcclient.h
+++ b/tests/ut_s9srpcclient/ut_s9srpcclient.h
@@ -117,6 +117,7 @@ class UtS9sRpcClient : public S9sUnitTest
         bool testImportDb();
         bool testDeleteDb();
         bool testListDb();
+        bool testInstallOpenBao();
 };
 
 class S9sRpcClientTester : public S9sRpcClient


### PR DESCRIPTION
- adds support for the SETUP_OPENBAO job, which installs and bootstraps an OpenBao instance on the host given by --nodes.
The job only produces a running instance, it does not point any controller at it, register it, or migrate anything.